### PR TITLE
Add missing paren

### DIFF
--- a/setup-phantomjs/action.yaml
+++ b/setup-phantomjs/action.yaml
@@ -44,7 +44,7 @@ runs:
                 NULL
               }
             if (!is.null(phantom_path)) {
-              system(paste0("echo 'path=", phantom_path, "' >> $GITHUB_OUTPUT'")
+              system(paste0("echo 'path=", phantom_path, "' >> $GITHUB_OUTPUT'"))
               found <- TRUE
             }
           }


### PR DESCRIPTION
Seeing an error in CI (e.g. https://github.com/rstudio/shiny/actions/runs/3851754436/jobs/6563259010):

```
Error: Error: unexpected symbol in:
"      system(paste0("echo 'path=", phantom_path, "' >> $GITHUB_OUTPUT'")
      found"
Execution halted
```