### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/internal/checkout/action.yaml
+++ b/.github/internal/checkout/action.yaml
@@ -1,5 +1,5 @@
 name: 'Checkout a repo with auto LFS support'
-description: 'If `=lfs` exists with `.gitattributes`, then add LFS support on checkout. If customization is needed, just call `actions/checkout@v2` directly'
+description: 'If `=lfs` exists with `.gitattributes`, then add LFS support on checkout. If customization is needed, just call `actions/checkout@v3` directly'
 author: 'Barret Schloerke'
 runs:
   using: "composite"
@@ -23,7 +23,7 @@ runs:
           Rscript -e 'cat("exists=true\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)'
         fi
       fi
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
     with:
       # Checkout with LFS support
       lfs: ${{ steps.lfs.output.exists == 'true' }}

--- a/setup-macOS-dependencies/README.md
+++ b/setup-macOS-dependencies/README.md
@@ -26,7 +26,7 @@ Known dependencies:
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: r-lib/actions/setup-r@v2
 - uses: rstudio/shiny-workflows/setup-macOS-dependencies@v1
   with:

--- a/setup-phantomjs/README.md
+++ b/setup-phantomjs/README.md
@@ -12,7 +12,7 @@ If `shinytest` is installed, the local package will also be installed for backgr
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 # `setup-r-package` calls `setup-phantomjs`
 - uses: rstudio/shiny-workflows/setup-r-package@v1
   with:

--- a/setup-r-package/README.md
+++ b/setup-r-package/README.md
@@ -12,7 +12,7 @@ This action installs `pandoc`, `R`, `macOS` and `Linux` system dependencies, pac
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: rstudio/shiny-workflows/setup-r-package@v1
   with:
     extra-packages: any::rcmdcheck

--- a/setup-tinytex/README.md
+++ b/setup-tinytex/README.md
@@ -10,7 +10,7 @@ This action installs `tinytex` if-and-only-if `tinytex` is a direct R package de
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 # `setup-r-package` calls `setup-tinytex`
 - uses: rstudio/shiny-workflows/setup-r-package@v1
   with:


### PR DESCRIPTION
This is to avoid the following warning:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2