### PR TITLE
Update default Pandoc version to 3.1.2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,7 +11,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "2.7.3"
+        default: "3.1.2"
         required: false
       extra-check-args:
         type: string

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,7 +11,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "3.1.2"
+        default: "3.x"
         required: false
       extra-check-args:
         type: string

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -11,7 +11,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "3.1.2"
+        default: "3.x"
         required: false
       node-version:
         type: string

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -11,7 +11,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "2.7.3"
+        default: "3.1.2"
         required: false
       node-version:
         type: string

--- a/.github/workflows/website-netlify.yaml
+++ b/.github/workflows/website-netlify.yaml
@@ -11,7 +11,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "3.1.2"
+        default: "3.x"
         required: false
       check-title:
         type: boolean
@@ -27,7 +27,6 @@ name: "`pkgdown` - Netlify"
 
 jobs:
   pkgdown:
-
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -68,11 +67,10 @@ jobs:
         id: netlify-deploy
         uses: nwtgck/actions-netlify@v1.1
         with:
-          publish-dir: 'reference'
+          publish-dir: "reference"
           production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message:
-            'Deploy from GHA: ${{ github.event.head_commit.message }} (${{ github.sha }})'
+          deploy-message: "Deploy from GHA: ${{ github.event.head_commit.message }} (${{ github.sha }})"
           enable-pull-request-comment: false
           enable-commit-comment: false
           enable-commit-status: true

--- a/.github/workflows/website-netlify.yaml
+++ b/.github/workflows/website-netlify.yaml
@@ -11,7 +11,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "2.7.3"
+        default: "3.1.2"
         required: false
       check-title:
         type: boolean

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -16,7 +16,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "3.1.2"
+        default: "3.x"
         required: false
       check-title:
         type: boolean
@@ -24,14 +24,13 @@ on:
         required: false
       clean:
         type: string
-        default: 'TRUE'
+        default: "TRUE"
         required: false
 
 name: "`pkgdown` - `gh-pages`"
 
 jobs:
   pkgdown:
-
     runs-on: ${{ inputs.runs-on }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -16,7 +16,7 @@ on:
         required: false
       pandoc-version:
         type: string
-        default: "2.7.3"
+        default: "3.1.2"
         required: false
       check-title:
         type: boolean

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
   * Parameters:
     * `extra-packages`: Installs extra packages not listed in the `DESCRIPTION` file to be installed. Link: https://github.com/r-lib/actions/tree/v2/setup-r-dependencies
     * `cache-version`: The cache key to be used. Link: https://github.com/r-lib/actions/tree/v2/setup-r-dependencies
-    * `pandoc-version`: Sets the pandoc version to be installed. Link: https://github.com/r-lib/actions/tree/master/setup-pandoc
+    * `pandoc-version`: Sets the pandoc version to be installed. Link: https://github.com/r-lib/actions/tree/HEAD/setup-pandoc . Defaults to `3.x` which installs a recent 3.x version of pandoc. (Similar behavior for `2.x`.)
     * `check-title`: If set, will disable `rmarkdown`'s check for having the vignette title and the document title match
 * `routine.yaml`
   * Performs many common tasks for packages in the shiny-verse and commits them back to the repo

--- a/setup-r-package/action.yaml
+++ b/setup-r-package/action.yaml
@@ -23,7 +23,7 @@ inputs:
     description: Value to be inserted into the cache key
     required: false
   pandoc-version:
-    default: "2.19.2"
+    default: "3.1.2"
     description: Pandoc version to be installed
     required: false
   packages:

--- a/setup-r-package/action.yaml
+++ b/setup-r-package/action.yaml
@@ -23,7 +23,7 @@ inputs:
     description: Value to be inserted into the cache key
     required: false
   pandoc-version:
-    default: "3.1.2"
+    default: "3.x"
     description: Pandoc version to be installed
     required: false
   packages:
@@ -42,9 +42,24 @@ inputs:
 runs:
   using: "composite"
   steps:
+
+    - name: Pandoc version
+      id: pandoc
+      shell: Rscript {0}
+      run: |
+        # Get corresponding pandoc version
+        pandoc_version <- "${{ inputs.pandoc-version }}"
+        switch(pandoc_version,
+          "default" =,
+          "3.x" = "3.1.2",
+          "2.x" = "2.19.2",
+          pandoc_version
+        )
+        cat("version=", pandoc_version, \n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+
     - uses: r-lib/actions/setup-pandoc@v2
       with:
-        pandoc-version: ${{ inputs.pandoc-version }}
+        pandoc-version: ${{ steps.pandoc.outputs.version }}
 
     - uses: r-lib/actions/setup-r@v2
       with:


### PR DESCRIPTION
Pandoc 2.x and Pandoc 3.x have some differences in behavior. I noticed this when my local copy of Pandoc did _not_ add leading spaces to bulleted lists, but the GHA copy of Pandoc added two leading spaces, resulting in `routine` check failures.

This PR brings all instances of Pandoc in this repo up to date.