### PR TITLE
Fix and tweak lock-threads workflow

### DIFF
--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -34,17 +34,21 @@ jobs:
           # Issue-locking options
           issue-inactive-days: ${{ inputs.issue-inactive-days }}
           issue-comment: >
-            This issue has been automatically locked. If you believe you have
+            This issue has been automatically locked. If you have
             found a related problem, please open a new issue (with
             [a reproducible example](https://community.rstudio.com/t/shiny-debugging-and-reprex-guide/10001)
             or [feature request](https://github.com/rstudio/shiny/wiki/Writing-Good-Feature-Requests))
             and link to this issue.
 
+            :raising_hand: Need help? [Connect with us on Discord or Posit Community.](https://shiny.posit.co/r/help.html).
+
           # Pull request-locking options
           pr-inactive-days: ${{ inputs.pr-inactive-days }}
           pr-comment: >
-            This pull request has been automatically locked. If you believe
-            you have found a related problem, please open a new issue (with
+            This pull request has been automatically locked. If you have
+            found a related problem, please open a new issue (with
             [a reproducible example](https://community.rstudio.com/t/shiny-debugging-and-reprex-guide/10001)
             or [feature request](https://github.com/rstudio/shiny/wiki/Writing-Good-Feature-Requests))
             and link to this pull request.
+
+            :raising_hand: Need help? [Connect with us on Discord or Posit Community.](https://shiny.posit.co/r/help.html).

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -40,7 +40,7 @@ jobs:
             or [feature request](https://github.com/rstudio/shiny/wiki/Writing-Good-Feature-Requests))
             and link to this issue.
 
-            :raising_hand: Need help? [Connect with us on Discord or Posit Community.](https://shiny.posit.co/r/help.html).
+            :raising_hand: Need help? [Connect with us on Discord or Posit Community](https://shiny.posit.co/r/help.html).
 
           # Pull request-locking options
           pr-inactive-days: ${{ inputs.pr-inactive-days }}
@@ -51,4 +51,4 @@ jobs:
             or [feature request](https://github.com/rstudio/shiny/wiki/Writing-Good-Feature-Requests))
             and link to this pull request.
 
-            :raising_hand: Need help? [Connect with us on Discord or Posit Community.](https://shiny.posit.co/r/help.html).
+            :raising_hand: Need help? [Connect with us on Discord or Posit Community](https://shiny.posit.co/r/help.html).

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -42,7 +42,7 @@ jobs:
 
           # Pull request-locking options
           pr-inactive-days: ${{ inputs.pr-inactive-days }}
-          pull-comment: >
+          pr-comment: >
             This pull request has been automatically locked. If you believe
             you have found a related problem, please open a new issue (with
             [a reproducible example](https://community.rstudio.com/t/shiny-debugging-and-reprex-guide/10001)


### PR DESCRIPTION
The lock-threads workflow used an incorrect key for `pr-comment` (thanks, copilot!).

I also edited the lock message slightly:

* "If you believe you have found" became "If you have found" (the hedging sounds a little skeptical)
* Added a link to the Shiny Help page where we share other ways to connect with us.

> This issue has been automatically locked. If you have found a related problem, please open a new issue (with [a reproducible example](https://community.rstudio.com/t/shiny-debugging-and-reprex-guide/10001) or [feature request](https://github.com/rstudio/shiny/wiki/Writing-Good-Feature-Requests)) and link to this issue.
> 
> :raising_hand: Need help? [Connect with us on Discord or Posit Community.](https://shiny.posit.co/r/help.html).