### PR TITLE
pak::pkg_deps() only allows for a single package definition

### DIFF
--- a/setup-macOS-dependencies/action.yaml
+++ b/setup-macOS-dependencies/action.yaml
@@ -32,9 +32,6 @@ runs:
             # Need for url remotes. See https://github.com/r-lib/actions/issues/562#issuecomment-1129088041
             install.packages("digest", repos = "http://cran.us.r-project.org")
           }
-          split_pkg_str <- function(txt) {
-            strsplit(txt, "[[:space:],]+")[[1]]
-          }
           pkg_deps <- NULL
           if (file.exists("DESCRIPTION")) {
             # Get packages like `{grDevices}` which will not be returned by `{pak}`
@@ -51,22 +48,20 @@ runs:
             # Local deps
             pkg_deps <- c(pkg_deps, pkg_names, pak::local_dev_deps(dependencies = TRUE)[["package"]])
           }
+          get_pkg_deps <- function(txt) {
+            pkgs <- strsplit(txt, "[[:space:],]+")[[1]]
+            unlist(lapply(pkgs, function(x) pak::pkg_deps(x, dependencies = TRUE)[["package"]]))
+          }
           # Needs deps; Must find all dependencies of of the needs pkgs
           if (nzchar("${{ inputs.needs }}") && file.exists("DESCRIPTION")) {
             needs_pkgs <- as.list(read.dcf("DESCRIPTION")[1,])[["Config/Needs/${{ inputs.needs }}"]]
             if (!is.null(needs_pkgs)) {
-              pkg_deps <- c(
-                pkg_deps,
-                pak::pkg_deps(split_pkg_str(needs_pkgs), dependencies = TRUE)[["package"]]
-              )
+              pkg_deps <- c(pkg_deps, get_pkg_deps(needs_pkgs))
             }
           }
           # Extra package deps
           if (nzchar("${{ inputs.extra-packages }}")) {
-            pkg_deps <- c(
-              pkg_deps,
-              pak::pkg_deps(split_pkg_str("${{ inputs.extra-packages }}"), dependencies = TRUE)[["package"]]
-            )
+            pkg_deps <- c(pkg_deps, get_pkg_deps("${{ inputs.extra-packages }}"))
           }
           pkg_deps <- unique(pkg_deps)
           cat("Packages found:\n"); print(pkg_deps)


### PR DESCRIPTION
This PR attempts to fix MacOS install errors that started recently appearing in shinycoreci's test results. Here's an example:

https://github.com/rstudio/shinycoreci/actions/runs/6092922510/job/16532934868#step:12:407

It appears the error is getting thrown by this line in `pak::pkg_deps()`:

https://github.com/r-lib/pak/blob/f7b0dbafd75a939fb6aa4f61e658a58e435ee5e8/R/package.R#L210-L211

Via the action workflow modified in this PR