### PR TITLE
feat(verify-no-new-commits): Don't fail in PR branches

### DIFF
--- a/.github/internal/verify-no-new-commits/action.yaml
+++ b/.github/internal/verify-no-new-commits/action.yaml
@@ -11,6 +11,12 @@ inputs:
   action:
     description: "Explains how to address the error on a new line"
     required: true
+  exit-code:
+    default: auto
+    description: >
+      Exit code to use if new commits are found. The default is `auto`, which
+      will exit cleanly ("0") in a PR or exit with error ("1") otherwise.
+    required: false
 runs:
   using: "composite"
   steps:
@@ -18,6 +24,16 @@ runs:
     shell: bash
     run: |
       if [ -n "`git cherry ${{ inputs.upstream }}`" ]; then
+        exitCode="${{ inputs.exit-code }}"
+        if [[ "$exitCode" == "auto" || -z "$exitCode" ]]; then
+          # If this is a PR, then set exit to 0, otherwise 1
+          if [[ -n "$GITHUB_HEAD_REF" ]]; then
+            exitCode=0
+          else
+            exitCode=1
+          fi
+        fi
+
         echo "Diff:"
         git diff ${{ inputs.upstream }}
         echo ""
@@ -26,5 +42,5 @@ runs:
         git cherry -v ${{ inputs.upstream }}
         echo "::error::Some auto-generated commits were found. ${{ inputs.statement }}"
         echo "::error::${{ inputs.action }}"
-        exit 1
+        exit $exitCode
       fi


### PR DESCRIPTION
Fixes #30

Adds `inputs.exit-code` to `verify-no-new-commits` with a default of `"auto"`. When `"auto"`, the action does not fail in PRs (with an error in the github actions summary), otherwise it fails.

"In a PR" is detected by consulting `$GITHUB_HEAD_REF` ([docs](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)):

> The head ref or source branch of the pull request in a workflow run. This property is only set when the event that triggers a workflow run is either `pull_request` or `pull_request_target`. For example, `feature-branch-1`.

The idea is that PR failures are almost always due to new commits being added to the branch, degrading the signal of failures in PR branches if cause only by the routine workflow.