### PR TITLE
Bump actions/setup-node to avoid deprecation warning

### DIFF
--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -132,7 +132,7 @@ jobs:
           }
       - name: Install node.js
         if: steps.package-json.outputs.exists
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ inputs.node-version }}"
       - name: "`yarn build`"


### PR DESCRIPTION
This PR bumps `actions/setup-node` to latest version 4 in order to avoid deprecation warning:

```
routine / routine
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v1.
For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```