### PR TITLE
unlink python's 2to3 so that brew link doesn't fail

### DIFF
--- a/setup-macOS-dependencies/action.yaml
+++ b/setup-macOS-dependencies/action.yaml
@@ -19,10 +19,6 @@ runs:
         # Install macOS system dependencies
         if (identical(Sys.getenv("RUNNER_OS", "NOT MAC"), "macOS")) {
           cat("::group::Install macOS system dependencies\n")
-          # Remove python's 2to3 link so that 'brew link' does not fail
-          if (file.exists("/usr/local/bin/2to3")) {
-            unlink("/usr/local/bin/2to3")
-          }
 
           # TODO-future; Find a way to not use `pak`? Hopefully RSPM will handle this in the future
           if (!require("pak", quietly = TRUE)) {
@@ -87,7 +83,8 @@ runs:
           # If the package exists, run the brew install commands
           if (length(cmds) > 0) {
             # Make sure exit is success
-            lapply(paste0("brew install ", cmds), function(cmd) {
+            # Make sure brew linking overwrites any links created. e.g. python's 2to3
+            lapply(paste0("brew install --overwrite ", cmds), function(cmd) {
               message(cmd)
               stopifnot(system(cmd) == 0)
               cmd

--- a/setup-macOS-dependencies/action.yaml
+++ b/setup-macOS-dependencies/action.yaml
@@ -19,6 +19,11 @@ runs:
         # Install macOS system dependencies
         if (identical(Sys.getenv("RUNNER_OS", "NOT MAC"), "macOS")) {
           cat("::group::Install macOS system dependencies\n")
+          # Remove python's 2to3 link so that 'brew link' does not fail
+          if (file.exists("/usr/local/bin/2to3")) {
+            unlink("/usr/local/bin/2to3")
+          }
+
           # TODO-future; Find a way to not use `pak`? Hopefully RSPM will handle this in the future
           if (!require("pak", quietly = TRUE)) {
             options(pak.no_extra_messages = TRUE)


### PR DESCRIPTION
We've recently started seeing `brew link` fail to install python3 because `/usr/local/bin/2to3` is present and brew link fails.

* https://github.com/rstudio/shinycoreci/actions/runs/7082248383/job/19273325383#step:12:847
* https://github.com/rstudio/shinycoreci/actions/runs/7082248383/job/19273322455#step:12:1091

This PR adds to the install macOS system dependencies group to remove the `2to3` link if it exists. This is apparently [somewhat common](https://github.com/search?q=%22rm+'/usr/local/bin/2to3'%22+path:*.yml&type=code).