### PR TITLE
fix(setup-r-package): Set pandoc version without using Rscript

### DIFF
--- a/setup-r-package/action.yaml
+++ b/setup-r-package/action.yaml
@@ -52,22 +52,20 @@ runs:
   steps:
 
     - name: Pandoc version
-      id: pandoc
-      shell: Rscript {0}
+      id: pandoc-version
+      shell: bash
       run: |
-        # Get corresponding pandoc version
-        pandoc_version <- "${{ inputs.pandoc-version }}"
-        pandoc_version <- switch(pandoc_version,
-          "default" =,
-          "3.x" = "3.1.11",
-          "2.x" = "2.19.2",
-          pandoc_version
-        )
-        cat("version=", pandoc_version, "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+        pandoc_version="${{ inputs.pandoc-version }}"
+        case $pandoc_version in
+          "default") pandoc_version="3.1.11" ;;
+          "3.x") pandoc_version="3.1.11" ;;
+          "2.x") pandoc_version="2.19.2" ;;
+        esac
+        echo "version=$pandoc_version" >> $GITHUB_OUTPUT
 
     - uses: r-lib/actions/setup-pandoc@v2
       with:
-        pandoc-version: ${{ steps.pandoc.outputs.version }}
+        pandoc-version: ${{ steps.pandoc-version.outputs.version }}
 
     - uses: r-lib/actions/setup-r@v2
       with:


### PR DESCRIPTION
We're seeing failures for [macOS with R 4.4.0](https://github.com/rstudio/bslib/actions/runs/8898510357/job/24435811661) like

```
Run # Get corresponding pandoc version
  # Get corresponding pandoc version
  pandoc_version <- "3.x"
  pandoc_version <- switch(pandoc_version,
    "default" =,
    "3.x" = "3.1.11",
    "2.x" = "2.19.2",
    pandoc_version
  )
  cat("version=", pandoc_version, "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
  Error: Rscript: command not found
```

This PR should fix the issue by rewriting the code expanding `"default"`, `"3.x"` and `"2.x"` into the full pandoc version in Bash rather than R. Clearly in the above linked failure we're using `Rscript` before its available -- my guess why this isn't a wide-spread problem is that we've been saved so far by caching and that with R 4.4.0 we're facing a cache miss where the problem surfaces.

While here I also renamed the step `pandoc-version` rather than `pandoc` for clarity.