### PR TITLE
chore(routine): Use `ubuntu-latest`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ on:
         type: string
         required: false
         # To test more versions, they must be separated by a space. Ex: `"ubuntu-18.04 ubuntu-20.04`
-        default: "ubuntu-20.04"
+        default: ubuntu-latest
       minimum-r-version:
         type: string
         required: false

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -29,7 +29,7 @@ name: routine
 
 jobs:
   routine:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website-netlify.yaml
+++ b/.github/workflows/website-netlify.yaml
@@ -27,7 +27,7 @@ name: "`pkgdown` - Netlify"
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -4,7 +4,7 @@ on:
       # Used by rstudio/shinyloadtest
       runs-on:
         type: string
-        default: "ubuntu-20.04"
+        default: ubuntu-latest
         required: false
       extra-packages:
         type: string


### PR DESCRIPTION
Switches the routine workflow to run on `ubuntu-latest` instead of `ubuntu-20.04`. 

This seems like a relativel safe change that will reduce our maintenance burden in the future: ideally this avoids us running into issue across repos that use the routine workflow and needing to come back here to update when the version we've pinned falls out of support.

If I'm wrong about this assumption and pinning the version theoretically saves us some future work, please let me know.