### PR TITLE
fix: Install R (latest release) for config step to work

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: release
-          install-r: false
+          install-r: true
 
       - name: oldrel-1
         id: oldrel-1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,6 +69,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: release
+          # Install R so that the `config` step below can execute (rstudio/shiny-workflows#41)
           install-r: true
 
       - name: oldrel-1


### PR DESCRIPTION
R isn't included in GitHub runner systems anymore. I'm hoping installing the R release will get us an R binary we can use for the config step.

Related failure: https://github.com/rstudio/bslib/actions/runs/12417670297/job/34669134270