### PR TITLE
fix: Run `yarn install` if either build or test are needed

### DIFF
--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -130,13 +130,15 @@ jobs:
               cat("test=true\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
             }
           }
+      
       - name: Install node.js
         if: steps.package-json.outputs.exists
         uses: actions/setup-node@v4
         with:
           node-version: "${{ inputs.node-version }}"
-      - name: "`yarn build`"
-        if: steps.package-json.outputs.build
+
+      - name: "`yarn install`"
+        if: steps.package-json.outputs.build || steps.package-json.outputs.test
         shell: bash
         run: |
           [ -d "srcts/types" ] && rm -r srcts/types
@@ -145,6 +147,11 @@ jobs:
             echo '::error::Error calling `yarn install --immutable`'
             exit 1
           fi
+
+      - name: "`yarn build`"
+        if: steps.package-json.outputs.build
+        shell: bash
+        run: |
           yarn build
           if [ $? != 0 ]; then
             echo '::error::Error calling `yarn build`'


### PR DESCRIPTION
Fixes an issue with the routine workflow where currently `yarn install` is only run if `yarn build` is needed. If `yarn build` **isn't needed** but `yarn test` **is**, then testing will fail because the install step was skipped. ([Example failing workflow run](https://github.com/rstudio/crosstalk/actions/runs/12691931491/job/35376095209?pr=157))

This PR moves `yarn install` to it's own step that's run if either `build` or `test` are needed.