### PR TITLE
feat: Format R code with `air`

### DIFF
--- a/.github/internal/air-format-r-code/action.yaml
+++ b/.github/internal/air-format-r-code/action.yaml
@@ -1,0 +1,74 @@
+name: 'Format R code with air'
+description: 'Automatically format R code with air.'
+author: 'Garrick Aden-Buie'
+
+inputs:
+  version:
+    description: Version of air
+    default: latest
+    required: false
+  check:
+    description: If `'true'`, only check that R code is formatted.
+    default: ""
+    required: false
+  path:
+    description: Path(s) to check as a space-separate single string
+    default: "."
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Install air (latest, Windows)
+      if: inputs.version == 'latest' && runner.os == 'Windows'
+      shell: powershell
+      run: |
+        irm https://github.com/posit-dev/air/releases/latest/download/air-installer.ps1 | iex
+    
+    - name: Install air (version, Windows)
+      if: inputs.version != 'latest' && runner.os == 'Windows'
+      shell: powershell
+      run: |
+        irm https://github.com/posit-dev/air/releases/download/${{ inputs.version }}/air-installer.ps1 | iex
+
+    - name: Install air (latest, Mac/Linux)
+      if: inputs.version == 'latest' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
+
+    - name: Install air (version, Mac/Linux)
+      if: inputs.version != 'latest' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        curl -LsSf https://github.com/posit-dev/air/releases/download/${{ inputs.version }}/air-installer.sh | sh
+
+    - name: air version
+      shell: bash
+      run: |
+        echo ""
+        echo "Formatting R code with $(air --version)"
+        echo ""
+          
+    - name: Check R code formatting
+      if: inputs.check == 'true'
+      shell: bash
+      run: air format --check ${{ inputs.path }}
+    
+    - name: Format R code
+      if: inputs.check != 'true'
+      shell: bash
+      run: air format ${{ inputs.path }}
+    
+    - name: Commit changes
+      if: inputs.check != 'true'
+      shell: bash
+      run: |
+        if find . -type f \( -name '*.r' -o -name '*.R' \) -exec git add -u {} +; then
+          echo "Staged modified R files"
+        else
+          echo "No changes found in any R files"
+        fi
+
+        git commit -m '`air format` (GitHub Actions)' || echo "No format changes to commit"

--- a/.github/internal/air-format-r-code/action.yaml
+++ b/.github/internal/air-format-r-code/action.yaml
@@ -4,7 +4,7 @@ author: 'Garrick Aden-Buie'
 
 inputs:
   version:
-    description: Version of air
+    description: Version of air, e.g. `0.1.2`.
     default: latest
     required: false
   check:

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -21,6 +21,10 @@ on:
         type: boolean
         default: true
         required: false
+      format-r-code:
+        type: boolean
+        default: false
+        required: false
     # secrets:
     #   token:
     #     required: true
@@ -63,6 +67,10 @@ jobs:
             any::lintr
             any::jsonlite
             ${{ inputs.extra-packages }}
+
+      - name: Format R code
+        if: inputs.format-r-code
+        uses: rstudio/shiny-workflows/.github/internal/air-format-r-code@5cf1df4c4dfd4e2dfc2e2c8fd416b2f0a06d3013
 
       - name: "`urlchecker::url_update()`; Update urls found in package; Only rc-v** branches"
         # Only perform if in an RC branch (`rc-vX.Y.Z`)

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Format R code
         if: inputs.format-r-code
-        uses: rstudio/shiny-workflows/.github/internal/air-format-r-code@feat/format-r-code
+        uses: rstudio/shiny-workflows/format-r-code@feat/format-r-code
 
       - name: "`urlchecker::url_update()`; Update urls found in package; Only rc-v** branches"
         # Only perform if in an RC branch (`rc-vX.Y.Z`)

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Format R code
         if: inputs.format-r-code
-        uses: rstudio/shiny-workflows/.github/internal/air-format-r-code@5cf1df4c4dfd4e2dfc2e2c8fd416b2f0a06d3013
+        uses: rstudio/shiny-workflows/.github/internal/air-format-r-code@feat/format-r-code
 
       - name: "`urlchecker::url_update()`; Update urls found in package; Only rc-v** branches"
         # Only perform if in an RC branch (`rc-vX.Y.Z`)

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Format R code
         if: inputs.format-r-code
-        uses: rstudio/shiny-workflows/format-r-code@feat/format-r-code
+        uses: rstudio/shiny-workflows/format-r-code@v1
 
       - name: "`urlchecker::url_update()`; Update urls found in package; Only rc-v** branches"
         # Only perform if in an RC branch (`rc-vX.Y.Z`)

--- a/format-r-code/README.md
+++ b/format-r-code/README.md
@@ -1,0 +1,62 @@
+# format-r-code
+
+## Format R code with air
+
+This GitHub Action automatically formats R code using the [air formatter](https://posit-dev.github.io/air), a new, blazing-fast R code formatter from [Posit](https://posit.co).
+
+This action installs the `air` formatter and uses it to format R code in your repository. It can either check if the code is properly formatted or automatically format the code and commit the changes.
+
+## Inputs
+
+| Input    | Description                                      | Default   | Required |
+|----------|--------------------------------------------------|-----------|----------|
+| version  | Version of air to use (e.g., `0.1.2`)            | `latest`  | No       |
+| check    | If `'true'`, only check that R code is formatted | `'false'` | No       |
+| path     | Path(s) to check (space-separated string)        | `'.'`     | No       |
+
+## Usage
+
+To use this action in your workflow, add the following step:
+
+```yaml
+- name: Format R code
+  uses: rstudio/shiny-workflows/format-r-code@v1
+```
+
+By default, `format-r-code` formats all R code in the repository. You can configure which directories or files are formatted with the `path` option. For example, the following formats only R files in the `R/` directory and the `app.R` file in the `my-example` Shiny app.
+
+```yaml
+- name: Format R code
+  uses: rstudio/shiny-workflows/format-r-code@v1
+  with:
+    path: R/ inst/examples-shiny/my-example/app.R
+```
+
+`format-r-code` commits all changes back to the repository, so be sure to configure your git user in the worflow:
+
+```yaml
+- name: Commit changes
+  run: |
+    git config --global user.name "$GITHUB_ACTOR"
+    git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+- name: Format R code
+  uses: rstudio/shiny-workflows/format-r-code@v1
+```
+
+On the other hand, if you'd rather check that the R code is already formatted as expected or have the workflow fail, set `check: true`:
+
+```yaml
+- name: Format R code
+  uses: rstudio/shiny-workflows/format-r-code@v1
+  with:
+    check: true
+```
+
+## Configuring air
+
+The best way to configure `air` for your personal style needs is to use an `air.toml` file in your repository. Read more about [configuring air on the air website](https://posit-dev.github.io/air/configuration.html).
+
+## License
+
+The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/format-r-code/action.yaml
+++ b/format-r-code/action.yaml
@@ -9,7 +9,7 @@ inputs:
     required: false
   check:
     description: If `'true'`, only check that R code is formatted.
-    default: ""
+    default: "false"
     required: false
   path:
     description: Path(s) to check as a space-separate single string


### PR DESCRIPTION
Adds a composite workflow `rstudio/shiny-workflows/format-r-code` that is included into the `routine` workflow to format R code with `air`.

This composite workflow can be used anywhere with

```yaml
- name: Format R code
  uses: rstudio/shiny-workflows/format-r-code@v1
```

In the routine workflow, I've put the formatting step behind `inputs.format-r-code`, which is `false` by default. To turn it on:

```yaml
  routine:
    uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@feat/format-r-code # @v1
    with:
      format-r-code: true
```

That lets us opt-in slowly initially or eventually we can change the default value and start formatting everything.

The composite workflow has additional inputs:

* `version` (default: `latest`) - which version of `air` to use so that we could pin to a specific version.
* `check` (default: false) - when `"true"` calls `air format --check`, which exits with a non-zero status if any files change, no changes are committed
* `path` (default: `.`) - paths passed to `air format ...`, can be files or directories, e.g. `R inst` to format R files in `R/` and `inst/` only. The current default formats all R files in the repo (aggressive but useful).

I've used this workflow in bslib as a demo: https://github.com/rstudio/bslib/pull/1167