### PR TITLE
chore(r-cmd-check): Add option to upload snapshots

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,7 +49,7 @@ on:
         required: false
       upload-snapshots: 
         type: boolean
-        default: false
+        default: true
         required: false
 
 name: R-CMD-check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,6 +47,10 @@ on:
         type: boolean
         default: true
         required: false
+      upload-snapshots: 
+        type: boolean
+        default: false
+        required: false
 
 name: R-CMD-check
 
@@ -214,6 +218,7 @@ jobs:
         with:
           check-dir: '"check"' # matches directory below
           args: 'c(${{ inputs.extra-check-args }}, "--no-manual", "--as-cran")'
+          upload-snapshots: ${{ input.upload-snapshots }}
 
       - name: "Show `testthat` output"
         if: always()


### PR DESCRIPTION
`r-lib/actions/check-r-package` has an option to upload snapshots, which is helpful if you want to have use CI to generate the variants. This PR just exposes the option in our `r-cmd-check` workflow.

https://github.com/r-lib/actions/tree/v2-branch/check-r-package