### PR TITLE
Bump GitHub Actions to v5

### DIFF
--- a/.github/internal/checkout/action.yaml
+++ b/.github/internal/checkout/action.yaml
@@ -1,5 +1,5 @@
 name: 'Checkout a repo with auto LFS support'
-description: 'If `=lfs` exists with `.gitattributes`, then add LFS support on checkout. If customization is needed, just call `actions/checkout@v4` directly'
+description: 'If `=lfs` exists with `.gitattributes`, then add LFS support on checkout. If customization is needed, just call `actions/checkout@v5` directly'
 author: 'Barret Schloerke'
 runs:
   using: "composite"
@@ -23,7 +23,7 @@ runs:
           Rscript -e 'cat("exists=true\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)'
         fi
       fi
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v5
     with:
       # Checkout with LFS support
       lfs: ${{ steps.lfs.output.exists == 'true' }}

--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Install node.js
         if: steps.package-json.outputs.exists
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "${{ inputs.node-version }}"
 

--- a/setup-macOS-dependencies/README.md
+++ b/setup-macOS-dependencies/README.md
@@ -29,7 +29,7 @@ Known dependencies:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 - uses: r-lib/actions/setup-r@v2
 - uses: rstudio/shiny-workflows/setup-macOS-dependencies@v1
   with:

--- a/setup-phantomjs/README.md
+++ b/setup-phantomjs/README.md
@@ -12,7 +12,7 @@ If `shinytest` is installed, the local package will also be installed for backgr
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 # `setup-r-package` calls `setup-phantomjs`
 - uses: rstudio/shiny-workflows/setup-r-package@v1
   with:

--- a/setup-phantomjs/action.yaml
+++ b/setup-phantomjs/action.yaml
@@ -59,7 +59,7 @@ runs:
         }
     - name: Restore PhantomJS cache
       if: ${{ steps.phantomjs.outputs.should-install == 'true' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.phantomjs.outputs.path }}
         key: ${{ runner.os }}-phantomjs-${{ inputs.cache-version }}
@@ -92,7 +92,7 @@ runs:
 
     - name: Save PhantomJS cache
       if: ${{ steps.phantomjs.outputs.should-install == 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.phantomjs.outputs.path }}
         key: ${{ runner.os }}-phantomjs-${{ inputs.cache-version }}

--- a/setup-r-package/README.md
+++ b/setup-r-package/README.md
@@ -36,7 +36,7 @@ The `pak-version` input controls which version of pak to use:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 - uses: rstudio/shiny-workflows/setup-r-package@v1
   with:
     extra-packages: any::rcmdcheck

--- a/setup-tinytex/README.md
+++ b/setup-tinytex/README.md
@@ -10,7 +10,7 @@ This action installs `tinytex` if-and-only-if `tinytex` is a direct R package de
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 # `setup-r-package` calls `setup-tinytex`
 - uses: rstudio/shiny-workflows/setup-r-package@v1
   with:


### PR DESCRIPTION
Update workflow and README references to newer Action major versions. Changed actions/checkout from v4 to v5, actions/setup-node from v4 to v5, and actions/cache restore/save from v4 to v5. Files modified: .github/internal/checkout/action.yaml, .github/workflows/routine.yaml, setup-macOS-dependencies/README.md, setup-phantomjs/README.md, setup-phantomjs/action.yaml, setup-r-package/README.md, and setup-tinytex/README.md. Keeps examples and internal composite action aligned with current upstream releases.