### PR TITLE
Allow R-CMD-check to target another repository

### DIFF
--- a/.github/internal/checkout/action.yaml
+++ b/.github/internal/checkout/action.yaml
@@ -1,6 +1,15 @@
 name: 'Checkout a repo with auto LFS support'
-description: 'If `=lfs` exists with `.gitattributes`, then add LFS support on checkout. If customization is needed, just call `actions/checkout@v5` directly'
+description: 'If `=lfs` exists with `.gitattributes`, then add LFS support on checkout. Supports optional repository/ref overrides. If customization is needed, just call `actions/checkout@v5` directly'
 author: 'Barret Schloerke'
+inputs:
+  repository:
+    description: 'Repository to checkout. Defaults to the calling repository.'
+    required: false
+    default: ''
+  ref:
+    description: 'Git ref to checkout. Defaults to the triggering ref for the calling repository, or the default branch for an overridden repository.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -24,6 +33,16 @@ runs:
         fi
       fi
   - uses: actions/checkout@v5
+    if: ${{ inputs.ref == '' }}
     with:
       # Checkout with LFS support
-      lfs: ${{ steps.lfs.output.exists == 'true' }}
+      lfs: ${{ steps.lfs.outputs.exists == 'true' }}
+      repository: ${{ inputs.repository || github.repository }}
+
+  - uses: actions/checkout@v5
+    if: ${{ inputs.ref != '' }}
+    with:
+      # Checkout with LFS support
+      lfs: ${{ steps.lfs.outputs.exists == 'true' }}
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ inputs.ref }}

--- a/.github/internal/checkout/action.yaml
+++ b/.github/internal/checkout/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: 'Git ref to checkout. Defaults to the triggering ref for the calling repository, or the default branch for an overridden repository.'
     required: false
     default: ''
+  token:
+    description: 'Token used for checkout and persisted credentials. Defaults to the workflow token.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -38,6 +42,7 @@ runs:
       # Checkout with LFS support
       lfs: ${{ steps.lfs.outputs.exists == 'true' }}
       repository: ${{ inputs.repository || github.repository }}
+      token: ${{ inputs.token || github.token }}
 
   - uses: actions/checkout@v5
     if: ${{ inputs.ref != '' }}
@@ -46,3 +51,4 @@ runs:
       lfs: ${{ steps.lfs.outputs.exists == 'true' }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}
+      token: ${{ inputs.token || github.token }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -77,6 +77,9 @@ on:
         type: boolean
         default: true
         required: false
+    secrets:
+      token:
+        required: false
 
 name: R-CMD-check
 
@@ -245,7 +248,7 @@ jobs:
         config: ${{ fromJSON(needs.setup.outputs.config) }}
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.token || secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout GitHub repo
@@ -253,6 +256,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
+          token: ${{ secrets.token }}
 
       - name: Install R, system dependencies, and package dependencies
         uses: rstudio/shiny-workflows/setup-r-package@v1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,6 +56,14 @@ on:
         type: boolean
         default: false
         required: false
+      repository:
+        type: string
+        default: ""
+        required: false
+      ref:
+        type: string
+        default: ""
+        required: false
       working-directory:
         type: string
         default: "."
@@ -123,6 +131,9 @@ jobs:
 
       - name: Checkout GitHub repo
         uses: rstudio/shiny-workflows/.github/internal/checkout@v1
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
 
       # R is a pre-installed software
       - name: Config
@@ -239,6 +250,9 @@ jobs:
     steps:
       - name: Checkout GitHub repo
         uses: rstudio/shiny-workflows/.github/internal/checkout@v1
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Install R, system dependencies, and package dependencies
         uses: rstudio/shiny-workflows/setup-r-package@v1

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ jobs:
     with:
       repository: rstudio/reactlog
       ref: main
+    secrets:
+      token: ${{ secrets.REACTLOG_AUTOMATION_TOKEN }}
 ```
 
 ## Workflows
@@ -103,6 +105,8 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).
     * `check-timeout-minutes`: Timeout in minutes for the check step. Defaults to `30`.
     * `check-depends-only`: If `true`, adds an extra job that checks the package with only dependencies installed (sets `_R_CHECK_DEPENDS_ONLY_=true`). Defaults to `true`.
+  * Secrets:
+    * `token`: Optional token used for checkout and GitHub API access. Defaults to the workflow `GITHUB_TOKEN`.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ jobs:
 
 > Note: Adjust the `8` in the schedule to match the number of letters in the package name to insert some time variance. This helps mitigate PAT rate limits when testing many packages on a schedule.
 
+To run checks for another repository from a host repository, pass the target repository and optional ref to the reusable workflow:
+
+```yaml
+jobs:
+  reactlog:
+    uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
+    with:
+      repository: rstudio/reactlog
+      ref: main
+```
+
 ## Workflows
 
 
@@ -87,6 +98,8 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `rtools-40`: If `true`, tests on Windows R 4.1 with Rtools40. Defaults to `true`.
     * `upload-snapshots`: If `true`, uploads testthat snapshots as artifacts. Defaults to `true`.
     * `upload-check-results`: If `true`, uploads check results on failure. Defaults to `false`.
+    * `repository`: Repository to check out before running the workflow. Defaults to the caller repository.
+    * `ref`: Git ref to check out from the target repository. Defaults to the caller ref, or the target repository's default branch when `repository` is overridden.
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).
     * `check-timeout-minutes`: Timeout in minutes for the check step. Defaults to `30`.
     * `check-depends-only`: If `true`, adds an extra job that checks the package with only dependencies installed (sets `_R_CHECK_DEPENDS_ONLY_=true`). Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ jobs:
 
 To run checks for another repository from a host repository, pass the target repository and optional ref to the reusable workflow:
 
+> Note: Cross-repository checks use the caller's `GITHUB_TOKEN`, which only has access to public repositories. This feature does not support private target repositories.
+
 ```yaml
 jobs:
   reactlog:
@@ -44,8 +46,6 @@ jobs:
     with:
       repository: rstudio/reactlog
       ref: main
-    secrets:
-      token: ${{ secrets.REACTLOG_AUTOMATION_TOKEN }}
 ```
 
 ## Workflows


### PR DESCRIPTION
## Summary
- add optional `repository` and `ref` inputs to the internal checkout action
- expose those inputs through the reusable `R-CMD-check` workflow
- document how a host repository can run checks for another repository, such as `rstudio/reactlog`

## Why
This allows a host repository like `rstudio/shinycoreci` to run the reusable `R-CMD-check` workflow against another repository without inlining the checkout and matrix logic locally.

## Validation
- parsed `.github/workflows/R-CMD-check.yaml` as YAML
- parsed `.github/internal/checkout/action.yaml` as YAML