### PR TITLE
Add cross-repo support to website workflow

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -26,10 +26,26 @@ on:
         type: string
         default: "TRUE"
         required: false
+      repository:
+        type: string
+        default: ""
+        required: false
+      ref:
+        type: string
+        default: ""
+        required: false
+      deploy:
+        description: "If true, build and deploy the pkgdown site even when the caller event is not a push. Useful for cross-repo schedule/manual runs."
+        type: boolean
+        default: false
+        required: false
 
       working-directory:
         type: string
         default: "."
+        required: false
+    secrets:
+      token:
         required: false
 
 name: "`pkgdown` - `gh-pages`"
@@ -38,11 +54,15 @@ jobs:
   pkgdown:
     runs-on: ${{ inputs.runs-on }}
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.token || secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout GitHub repo
         uses: rstudio/shiny-workflows/.github/internal/checkout@v1
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.token }}
 
       - name: Install R, system dependencies, and package dependencies
         uses: rstudio/shiny-workflows/setup-r-package@v1
@@ -62,18 +82,19 @@ jobs:
           name: website
 
       - name: Verify index reference (PR)
-        if: github.event_name != 'push'
+        if: ${{ !inputs.deploy && github.event_name != 'push' }}
         uses: rstudio/shiny-workflows/.github/internal/verify-pkgdown@v1
         with:
           check-title: ${{ inputs.check-title }}
           working-directory: ${{ inputs.working-directory }}
 
       - name: Setup git (push)
+        if: ${{ inputs.deploy || github.event_name == 'push' }}
         uses: rstudio/shiny-workflows/.github/internal/setup-git@v1
 
       - name: Build and deploy pkgdown site (push)
         working-directory: ${{ inputs.working-directory }}
-        if: github.event_name == 'push'
+        if: ${{ inputs.deploy || github.event_name == 'push' }}
         shell: Rscript {0}
         run: |
           if ("${{inputs.check-title}}" == "false") options(rmarkdown.html_vignette.check_title = FALSE)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `pandoc-version`: Sets the pandoc version to be installed. Link: https://github.com/r-lib/actions/tree/HEAD/setup-pandoc . Defaults to `3.x` which installs a recent 3.x version of pandoc. (Similar behavior for `2.x`.)
     * `check-title`: If `true`, will check that vignette titles and document titles match. Defaults to `true`.
     * `clean`: Whether to clean the site before building. Defaults to `"TRUE"`.
+    * `repository`: Repository to check out before running the workflow. Defaults to the caller repository.
+    * `ref`: Git ref to check out from the target repository. Defaults to the caller ref, or the target repository's default branch when `repository` is overridden.
+    * `deploy`: If `true`, build and deploy the pkgdown site even when the caller event is not a push. Defaults to `false`.
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).
+  * Secrets:
+    * `token`: Optional token used for checkout, package installation, and pushing `gh-pages`. Defaults to the workflow `GITHUB_TOKEN`.
 * `routine.yaml`
   * Performs many common tasks for packages in the shiny-verse and commits them back to the repo
     * Check for url redirects in `rc-v**` branches


### PR DESCRIPTION
## Summary
- add optional `repository`, `ref`, and `deploy` inputs to `website.yaml`
- accept an optional `token` secret for cross-repo checkout and deployment
- document the new cross-repo website parameters in the README

## Why
`website.yaml` currently assumes it is running in the caller repository and only deploys on `push` events. This change lets a host repository explicitly target another repository and opt into deployment on schedule/manual runs.

## Notes
- This PR is stacked on #57 because it depends on the checkout action repository/ref/token override support.
- Existing behavior is preserved by default: deployment still only happens on `push` unless `deploy: true` is supplied.

## Validation
- parsed `.github/workflows/website.yaml` as YAML