### PR TITLE
feat: Expose an `error-on` input on `R-CMD-check.yaml`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,13 @@ on:
         # default: '"--no-manual"'
         default: '"--compact-vignettes=gs+qpdf"'
         required: false
+      error-on:
+        type: string
+        # Note: `'"note"'` can be flaky in CI even for a locally clean package, due to
+        # environment NOTEs such as "checking CRAN incoming feasibility" and
+        # "checking for future file timestamps".
+        default: '"warning"'
+        required: false
       macOS:
         type: string
         default: "macOS-latest"
@@ -269,6 +276,7 @@ jobs:
           check-dir: '"check"' # matches directory below
           args: 'c(${{ inputs.extra-check-args }}, "--no-manual", "--as-cran")'
           build_args: 'c(${{ inputs.extra-check-build-args }}, "--no-manual")'
+          error-on: ${{ inputs.error-on }}
           upload-snapshots: ${{ inputs.upload-snapshots }}
           # Use the cache-version to separate the results from other checks with the same setup.
           artifact-name: ${{ format('{0}-{1}-r{2}-{3}-{4}-results', runner.os, runner.arch, matrix.config.r, inputs.cache-version, matrix.config.id || strategy.job-index ) }}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
   * Parameters:
     * `extra-packages`, `cache-version`, `pandoc-version`: Same as in `website.yaml`
     * `extra-check-args`, `extra-check-build-args`: Arguments passed in addition to the default check `args`/`build-args` of https://github.com/r-lib/actions/blob/v2/check-r-package/
+    * `error-on`: Condition that makes `R CMD check` fail, forwarded to `rcmdcheck`'s `error_on`. Must be a quoted R string, e.g. `'"note"'`. Defaults to `'"warning"'`. Note that `'"note"'` can be flaky in CI even for a locally clean package, due to environment NOTEs such as _checking CRAN incoming feasibility_ and _checking for future file timestamps_.
     * `macOS`: `macOS` runtime to use. Set to `false` to disable testing on macOS. Defaults to `"macOS-latest"`.
     * `windows`: `windows` runtime to use. Set to `false` to disable testing on Windows. Defaults to `"windows-latest"`.
     * `ubuntu`: `ubuntu` runtime to use. To use more than one ubuntu value, send in a value separated by a space. For example, to test on ubuntu 22.04 and 24.04, use `"ubuntu-22.04 ubuntu-24.04"`. The first `ubuntu` value will be tested using the `"devel"` R version. Set to `false` to disable testing on Ubuntu. Defaults to `"ubuntu-latest"`.


### PR DESCRIPTION
Closes #60

## Summary

`R-CMD-check.yaml` called `r-lib/actions/check-r-package` without setting `error-on`, so the action's own default of `'"warning"'` applied and a NOTE always passed CI, with no input to change that. `extra-check-args` doesn't help — those are `R CMD check` arguments, not `rcmdcheck`'s `error_on`.

This adds an `error-on` string input to the reusable workflow and forwards it to the action. The default is `'"warning"'`, identical to the action's default, so every existing caller is byte-for-byte unchanged; only repos that opt in see different behavior. The value follows the same YAML-quoting convention as `check-dir` / `extra-check-args` — it is interpolated into R code, so it must be a quoted R string.

`'"note"'` can be flaky in CI even for a locally clean package, because of environment NOTEs like *checking CRAN incoming feasibility* and *checking for future file timestamps*. That is documented on the input and in the README, and is why this is opt-in per repo rather than the default.

## Verification

A caller that wants NOTEs to fail:

```yaml
jobs:
  R-CMD-check:
    uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
    with:
      error-on: '"note"'
```

Callers that omit `error-on` produce the same `rcmdcheck()` call as before.