### PR TITLE
R-CMD-check: Derive Windows R versions from oldrel instead of hardcoding

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,10 +51,6 @@ on:
         type: boolean
         required: false
         default: false
-      rtools-40:
-        type: boolean
-        default: true
-        required: false
       upload-snapshots:
         type: boolean
         default: true
@@ -147,7 +143,6 @@ jobs:
           ubuntu_arr = re.split(r'[,\s]+', "${{ inputs.ubuntu }}")
           has_src = os.path.isdir("src")
           min_r_ver = "${{ inputs.minimum-r-version }}"
-          test_on_rtools40 = "${{ inputs.rtools-40 }}" == "true"
           force_windows_src = "${{ inputs.force-windows-src }}" == "true"
           if force_windows_src:
               has_src = True
@@ -180,13 +175,6 @@ jobs:
                   return True
               return r_ver >= min_r_ver
 
-          def rtools_version(r_ver):
-              # "4.4.1" -> "44". R 4.0 and R 4.1 both use Rtools40.
-              major, minor = r_ver.split(".")[0:2]
-              if (major, minor) == ("4", "1"):
-                  return "40"
-              return major + minor
-
           config = []
 
           ## macOS
@@ -203,12 +191,11 @@ jobs:
           # https://www.tidyverse.org/blog/2019/04/r-version-support/
           # These are resolved from `oldrel-*` (rather than hardcoded) so that
           # outdated R versions drop off the matrix as new versions are released.
-          windows_oldrel = ["oldrel1", "oldrel2", "oldrel3"]
-          if test_on_rtools40:
-              windows_oldrel.append("oldrel4")
-          for oldrel in windows_oldrel:
+          # No `rtools-version` is set; `r-lib/actions/setup-r` resolves a
+          # suitable Rtools for the given R version.
+          for oldrel in ["oldrel1", "oldrel2", "oldrel3", "oldrel4"]:
               if has_src and is_valid_os(windows, rver[oldrel]):
-                  config.append(job(windows, rver[oldrel], **{"rtools-version": rtools_version(rver[oldrel])}))
+                  config.append(job(windows, rver[oldrel]))
 
           # Ubuntu
           if is_valid_os(ubuntu_arr[0], rver["devel"]):
@@ -261,7 +248,6 @@ jobs:
         uses: rstudio/shiny-workflows/setup-r-package@v1
         with:
           working-directory: ${{ inputs.working-directory }}
-          rtools-version: ${{ matrix.config.rtools-version }}
           pandoc-version: ${{ inputs.pandoc-version }}
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -180,6 +180,13 @@ jobs:
                   return True
               return r_ver >= min_r_ver
 
+          def rtools_version(r_ver):
+              # "4.4.1" -> "44". R 4.0 and R 4.1 both use Rtools40.
+              major, minor = r_ver.split(".")[0:2]
+              if (major, minor) == ("4", "1"):
+                  return "40"
+              return major + minor
+
           config = []
 
           ## macOS
@@ -191,14 +198,17 @@ jobs:
               config.append(job(windows, "devel"))
           if is_valid_os(windows, rver["release"]):
               config.append(job(windows, rver["release"]))
-          if has_src and is_valid_os(windows, "4.4"):
-              config.append(job(windows, "4.4", **{"rtools-version": "44"}))
-          if has_src and is_valid_os(windows, "4.3"):
-              config.append(job(windows, "4.3", **{"rtools-version": "43"}))
-          if has_src and is_valid_os(windows, "4.2"):
-              config.append(job(windows, "4.2", **{"rtools-version": "42"}))
-          if has_src and test_on_rtools40 and is_valid_os(windows, "4.1"):
-              config.append(job(windows, "4.1", **{"rtools-version": "40"}))
+          # Follow the tidyverse R version support policy of R release plus the
+          # four previous versions:
+          # https://www.tidyverse.org/blog/2019/04/r-version-support/
+          # These are resolved from `oldrel-*` (rather than hardcoded) so that
+          # outdated R versions drop off the matrix as new versions are released.
+          windows_oldrel = ["oldrel1", "oldrel2", "oldrel3"]
+          if test_on_rtools40:
+              windows_oldrel.append("oldrel4")
+          for oldrel in windows_oldrel:
+              if has_src and is_valid_os(windows, rver[oldrel]):
+                  config.append(job(windows, rver[oldrel], **{"rtools-version": rtools_version(rver[oldrel])}))
 
           # Ubuntu
           if is_valid_os(ubuntu_arr[0], rver["devel"]):

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `ubuntu`: `ubuntu` runtime to use. To use more than one ubuntu value, send in a value separated by a space. For example, to test on ubuntu 22.04 and 24.04, use `"ubuntu-22.04 ubuntu-24.04"`. The first `ubuntu` value will be tested using the `"devel"` R version. Set to `false` to disable testing on Ubuntu. Defaults to `"ubuntu-latest"`.
     * `minimum-r-version`: If provided, only R versions >= to `minimum-r-version` will be created in the matrix. Great for dependencies that will not install on earlier R versions.
     * `force-windows-src`: If `true`, forces the check to assume the package has compiled code even if it doesn't. Defaults to `false`.
-    * `rtools-40`: If `true`, tests on Windows R 4.1 with Rtools40. Defaults to `true`.
+    * `rtools-40`: If `true`, tests on Windows with the oldest R version supported by the [tidyverse R version support policy](https://www.tidyverse.org/blog/2019/04/r-version-support/) (`oldrel-4`, i.e. four releases behind the current release). Defaults to `true`.
     * `upload-snapshots`: If `true`, uploads testthat snapshots as artifacts. Defaults to `true`.
     * `upload-check-results`: If `true`, uploads check results on failure. Defaults to `false`.
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `ubuntu`: `ubuntu` runtime to use. To use more than one ubuntu value, send in a value separated by a space. For example, to test on ubuntu 22.04 and 24.04, use `"ubuntu-22.04 ubuntu-24.04"`. The first `ubuntu` value will be tested using the `"devel"` R version. Set to `false` to disable testing on Ubuntu. Defaults to `"ubuntu-latest"`.
     * `minimum-r-version`: If provided, only R versions >= to `minimum-r-version` will be created in the matrix. Great for dependencies that will not install on earlier R versions.
     * `force-windows-src`: If `true`, forces the check to assume the package has compiled code even if it doesn't. Defaults to `false`.
-    * Windows R versions follow the [tidyverse R version support policy](https://www.tidyverse.org/blog/2019/04/r-version-support/) (R release plus the four previous versions) and are resolved automatically. Packages with compiled code (a `src/` directory) are additionally tested on `devel` and on `oldrel-1` through `oldrel-4`.
     * `upload-snapshots`: If `true`, uploads testthat snapshots as artifacts. Defaults to `true`.
     * `upload-check-results`: If `true`, uploads check results on failure. Defaults to `false`.
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `ubuntu`: `ubuntu` runtime to use. To use more than one ubuntu value, send in a value separated by a space. For example, to test on ubuntu 22.04 and 24.04, use `"ubuntu-22.04 ubuntu-24.04"`. The first `ubuntu` value will be tested using the `"devel"` R version. Set to `false` to disable testing on Ubuntu. Defaults to `"ubuntu-latest"`.
     * `minimum-r-version`: If provided, only R versions >= to `minimum-r-version` will be created in the matrix. Great for dependencies that will not install on earlier R versions.
     * `force-windows-src`: If `true`, forces the check to assume the package has compiled code even if it doesn't. Defaults to `false`.
-    * `rtools-40`: If `true`, tests on Windows with the oldest R version supported by the [tidyverse R version support policy](https://www.tidyverse.org/blog/2019/04/r-version-support/) (`oldrel-4`, i.e. four releases behind the current release). Defaults to `true`.
+    * Windows R versions follow the [tidyverse R version support policy](https://www.tidyverse.org/blog/2019/04/r-version-support/) (R release plus the four previous versions) and are resolved automatically. Packages with compiled code (a `src/` directory) are additionally tested on `devel` and on `oldrel-1` through `oldrel-4`.
     * `upload-snapshots`: If `true`, uploads testthat snapshots as artifacts. Defaults to `true`.
     * `upload-check-results`: If `true`, uploads check results on failure. Defaults to `false`.
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).


### PR DESCRIPTION
Fixes #46

## Problem

The Windows section of the `R-CMD-check` matrix hardcoded R `4.4`, `4.3`, `4.2`, and `4.1`, each with an explicit `rtools-version`. That list only changes when someone edits it by hand, which cuts both ways:

- outdated R versions linger on the matrix (the original complaint in #46 — R 3.6 was only dropped by a manual edit in #45),
- and each new R release silently *loses* coverage until someone adds the new version.

As of today R release is 4.6.1, so the hardcoded list was already stale: it topped out at 4.4 and still tested R 4.1, which has aged out of the [tidyverse R version support policy](https://www.tidyverse.org/blog/2019/04/r-version-support/) window.

## Change

Resolve the Windows R versions from the `oldrel-*` `setup-r` outputs that the `setup` job already computes, exactly like the Ubuntu matrix does. This tracks the tidyverse policy — release plus the four previous versions — with no maintenance.

```python
for oldrel in ["oldrel1", "oldrel2", "oldrel3", "oldrel4"]:
    if has_src and is_valid_os(windows, rver[oldrel]):
        config.append(job(windows, rver[oldrel]))
```

Two things dropped along the way:

- **The explicit `rtools-version`.** `r-lib/actions/setup-r` resolves a suitable Rtools from the R version when the input is empty — `setup-r/src/installer.ts:499-509` falls back to `version.rtools` / `version.rtools_url`, which come from the r-hub `rversions/resolve` API. Confirmed against that API for every version this matrix requests:

  | requested | R | rtools |
  | --- | --- | --- |
  | `release` | 4.6.1 | 45 |
  | `oldrel/1` | 4.5.3 | 45 |
  | `oldrel/2` | 4.4.3 | 44 |
  | `oldrel/3` | 4.3.3 | 43 |
  | `oldrel/4` | 4.2.3 | 42 |
  | `4.1.3` | 4.1.3 | 40 (CRAN `rtools40-x86_64.exe`) |

  Note the old R 4.1 → Rtools40 special case is handled correctly by the API, so nothing is lost if `oldrel-4` ever reaches back that far again.

- **The `rtools-40` input.** It gated the oldest Windows version, which is now always tested. A GitHub code search across the 52 repos that consume this workflow (shiny, bslib, httpuv, htmltools, promises, chromote, shinytest2, r-lib/{R6,cachem,fastmap,later}, …) found **no** repo that sets it — it was dead configuration, and every consumer was running on the `true` default. Its README parameter bullet is removed along with it. Removing it is therefore a no-op in practice, though it is technically a breaking input change for any private consumer that sets it.

## Behavior

Simulating the config script with the current `setup-r` outputs:

| scenario | Windows jobs generated |
| --- | --- |
| default (release 4.6.1) | devel, 4.6.1, 4.5.3, 4.4.3, 4.3.3, 4.2.3 |
| `minimum-r-version: 4.4` | devel, 4.6.1, 4.5.3, 4.4.3 |
| `windows: false` | none |
| package without `src/` | 4.6.1 only |

R 3.6 / 4.0 can no longer appear on the matrix at all, and the list advances on its own with each R release.

## Testing notes

Verified by extracting the inline Python config script and running it against mocked `setup-r` outputs (the cases above), plus live queries to the r-hub resolve API for the Rtools table. This repo has no test suite, so the real validation is a consuming repo pointing at `@schloerke/issue-46-windows-oldrel` and confirming the generated matrix and that Rtools installs on the older Windows jobs.

