### PR TITLE
website: Support manually triggered site rebuilds

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -61,8 +61,10 @@ jobs:
         with:
           name: website
 
+      # Deploy on `push`, and on a manual/API trigger so that a site can be
+      # rebuilt on demand. Otherwise (`pull_request`, `schedule`), only verify.
       - name: Verify index reference (PR)
-        if: github.event_name != 'push'
+        if: github.event_name != 'push' && github.event_name != 'workflow_dispatch' && github.event_name != 'repository_dispatch'
         uses: rstudio/shiny-workflows/.github/internal/verify-pkgdown@v1
         with:
           check-title: ${{ inputs.check-title }}
@@ -73,7 +75,7 @@ jobs:
 
       - name: Build and deploy pkgdown site (push)
         working-directory: ${{ inputs.working-directory }}
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
         shell: Rscript {0}
         run: |
           if ("${{inputs.check-title}}" == "false") options(rmarkdown.html_vignette.check_title = FALSE)

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -41,6 +41,14 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      # Deploy on `push`, and on a manual/API trigger so that a site can be
+      # rebuilt on demand. Otherwise (`pull_request`, `schedule`), only verify.
+      - name: Should the site be deployed?
+        id: deploy
+        shell: bash
+        run: |
+          echo "value=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout GitHub repo
         uses: rstudio/shiny-workflows/.github/internal/checkout@v1
 
@@ -61,10 +69,8 @@ jobs:
         with:
           name: website
 
-      # Deploy on `push`, and on a manual/API trigger so that a site can be
-      # rebuilt on demand. Otherwise (`pull_request`, `schedule`), only verify.
-      - name: Verify index reference (PR)
-        if: github.event_name != 'push' && github.event_name != 'workflow_dispatch' && github.event_name != 'repository_dispatch'
+      - name: Verify index reference (no deploy)
+        if: steps.deploy.outputs.value != 'true'
         uses: rstudio/shiny-workflows/.github/internal/verify-pkgdown@v1
         with:
           check-title: ${{ inputs.check-title }}
@@ -73,9 +79,9 @@ jobs:
       - name: Setup git (push)
         uses: rstudio/shiny-workflows/.github/internal/setup-git@v1
 
-      - name: Build and deploy pkgdown site (push)
+      - name: Build and deploy pkgdown site (deploy)
         working-directory: ${{ inputs.working-directory }}
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+        if: steps.deploy.outputs.value == 'true'
         shell: Rscript {0}
         run: |
           if ("${{inputs.check-title}}" == "false") options(rmarkdown.html_vignette.check_title = FALSE)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 8 * * 1' # every monday
+  workflow_dispatch:
 
 name: Package checks
 
@@ -43,6 +44,8 @@ There are three main reusable workflows to be used by packages in the shiny-vers
 * `website.yaml`
   * This is a wrapper for building a `{pkgdown}` website and deploying it to the `gh-pages` branch of the repo.
   * Packages included in the `DESCRIPTION` field `Config/Needs/website` will also be installed
+  * The site is deployed on `push`, `workflow_dispatch`, and `repository_dispatch` events. On other events (such as `pull_request`), the site is only built and verified.
+  * To rebuild a site on demand without running the rest of `Package checks`, copy [`examples/website.yaml`](./examples/website.yaml) into your repo. See [the examples README](./examples/README.md#website).
   * Parameters:
     * `runs-on`: The runner to use for the job. Defaults to `ubuntu-latest`.
     * `extra-packages`: Installs extra packages not listed in the `DESCRIPTION` file to be installed. Link: https://github.com/r-lib/actions/tree/v2/setup-r-dependencies

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
   * This is a wrapper for building a `{pkgdown}` website and deploying it to the `gh-pages` branch of the repo.
   * Packages included in the `DESCRIPTION` field `Config/Needs/website` will also be installed
   * The site is deployed on `push`, `workflow_dispatch`, and `repository_dispatch` events. On other events (such as `pull_request`), the site is only built and verified.
-  * To rebuild a site on demand without running the rest of `Package checks`, copy [`examples/website.yaml`](./examples/website.yaml) into your repo. See [the examples README](./examples/README.md#website).
+  * To run the site as its own workflow, so that it can also be rebuilt on demand without running the rest of `Package checks`, copy [`examples/website.yaml`](./examples/website.yaml) into your repo and drop the `website` job from `Package checks`. See [the examples README](./examples/README.md#website).
   * Parameters:
     * `runs-on`: The runner to use for the job. Defaults to `ubuntu-latest`.
     * `extra-packages`: Installs extra packages not listed in the `DESCRIPTION` file to be installed. Link: https://github.com/r-lib/actions/tree/v2/setup-r-dependencies

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 ## website
 
-Rebuilds and deploys the `{pkgdown}` site on demand. The `website` job in the standard `Package checks` workflow only runs on push/PR/schedule, so this workflow gives you a way to trigger a site rebuild by hand (for example, while debugging a rendering problem) without pushing a commit or re-running the full check matrix.
+Builds and deploys the `{pkgdown}` site as its own workflow, rather than as the `website` job inside `Package checks`. The site is still built on every push and pull request, and it can additionally be rebuilt on demand (for example, while debugging a rendering problem) without pushing a commit or re-running the full check matrix.
 
 ### Usage
 
@@ -21,7 +21,9 @@ Then trigger it from the **Actions** tab (*Website* → *Run workflow*), or via 
 gh workflow run website.yaml
 ```
 
-The workflow is trigger-only (`workflow_dispatch` / `repository_dispatch`), so it does not duplicate the site build that already happens on push. It accepts the same parameters as `website.yaml`; add a `with:` block to the `website` job to set them.
+**Remove the `website` job from your `Package checks` workflow when you adopt this file**, otherwise the site is built twice on every push.
+
+The workflow accepts the same parameters as `website.yaml`; add a `with:` block to the `website` job to set them.
 
 ## lock-threads
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,28 @@
 # Examples
 
+## website
+
+Rebuilds and deploys the `{pkgdown}` site on demand. The `website` job in the standard `Package checks` workflow only runs on push/PR/schedule, so this workflow gives you a way to trigger a site rebuild by hand (for example, while debugging a rendering problem) without pushing a commit or re-running the full check matrix.
+
+### Usage
+
+```r
+usethis::use_github_action(
+  url = file.path(
+    "https://raw.githubusercontent.com/rstudio/shiny-workflows",
+    "main/examples/website.yaml"
+  )
+)
+```
+
+Then trigger it from the **Actions** tab (*Website* → *Run workflow*), or via the API:
+
+```bash
+gh workflow run website.yaml
+```
+
+The workflow is trigger-only (`workflow_dispatch` / `repository_dispatch`), so it does not duplicate the site build that already happens on push. It accepts the same parameters as `website.yaml`; add a `with:` block to the `website` job to set them.
+
 ## lock-threads
 
 This action uses the [lock-threads](https://github.com/marketplace/actions/lock-threads) action to lock issues and pull requests that have been inactive for a specified period of time.

--- a/examples/website.yaml
+++ b/examples/website.yaml
@@ -16,8 +16,10 @@ on:
 name: Website
 
 concurrency:
-  # Serialize runs per branch so that two deploys never race on `gh-pages`
-  group: website-${{ github.ref }}
+  # Cancel superseded runs on a pull request, but let pushes queue up so that
+  # two deploys never race on `gh-pages`
+  group: website-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   website:

--- a/examples/website.yaml
+++ b/examples/website.yaml
@@ -1,0 +1,19 @@
+# Workflow derived from https://github.com/rstudio/shiny-workflows
+#
+# Rebuilds and deploys the `{pkgdown}` site on demand, without having to run
+# (or wait on) the rest of the `Package checks` workflow.
+#
+# This workflow only runs when triggered manually, so it does not duplicate the
+# `website` job that already runs on push in `Package checks`.
+on:
+  workflow_dispatch:
+  repository_dispatch: { types: [website] }
+
+name: Website
+
+concurrency:
+  group: website
+
+jobs:
+  website:
+    uses: rstudio/shiny-workflows/.github/workflows/website.yaml@v1

--- a/examples/website.yaml
+++ b/examples/website.yaml
@@ -1,18 +1,23 @@
 # Workflow derived from https://github.com/rstudio/shiny-workflows
 #
-# Rebuilds and deploys the `{pkgdown}` site on demand, without having to run
-# (or wait on) the rest of the `Package checks` workflow.
+# Builds the `{pkgdown}` site on push and pull request, and lets the site be
+# rebuilt on demand without running (or waiting on) the rest of the
+# `Package checks` workflow.
 #
-# This workflow only runs when triggered manually, so it does not duplicate the
-# `website` job that already runs on push in `Package checks`.
+# NOTE: If you adopt this workflow, remove the `website` job from your
+# `Package checks` workflow. Otherwise the site is built twice on every push.
 on:
+  push:
+    branches: [main, rc-**]
+  pull_request:
   workflow_dispatch:
   repository_dispatch: { types: [website] }
 
 name: Website
 
 concurrency:
-  group: website
+  # Serialize runs per branch so that two deploys never race on `gh-pages`
+  group: website-${{ github.ref }}
 
 jobs:
   website:


### PR DESCRIPTION
Fixes #25

## Problem

The pkgdown build was spun out of `routine.yaml` into `website.yaml` a while back, but the actual goal of #25 — *"you can't manually trigger a website rebuild"* — was never reachable, for two reasons:

1. The deploy step in `website.yaml` was gated on `github.event_name == 'push'`. A manually triggered run would take the *"Verify index reference"* path instead: it would build the site, verify it, and then throw it away without deploying.
2. The `Package checks` template in the README has no `workflow_dispatch:` trigger, so there was nothing to trigger by hand in the first place.

## Change

- **`.github/workflows/website.yaml`**: deploy on `workflow_dispatch` and `repository_dispatch` in addition to `push`. `pull_request` and `schedule` are unchanged — they still only build and verify.

  The condition is computed once in a pre-step rather than spelled out (and negated) at each use site:

  ```yaml
  - name: Should the site be deployed?
    id: deploy
    shell: bash
    run: |
      echo "value=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}" >> "$GITHUB_OUTPUT"
  ```

  ...then `if: steps.deploy.outputs.value == 'true'` on the deploy step and `!= 'true'` on the verify step. The two steps are renamed accordingly, since neither is push-specific any more.

- **`examples/website.yaml`** (new): a caller workflow consumers can copy to run the site as its own workflow. It builds on the same `push` / `pull_request` triggers as `Package checks` so the site is still built often, and adds `workflow_dispatch` / `repository_dispatch` so it can be rebuilt on demand without re-running the full `R-CMD-check` matrix.

  Its concurrency group is `website-${{ github.event.pull_request.number || github.ref }}` with `cancel-in-progress` only on pull requests: superseded PR builds are cancelled rather than queued, while pushes queue so two deploys never race on `gh-pages`.

  Adopting this file means dropping the `website` job from `Package checks` — otherwise the site is built twice per push. This is called out in the file header and in both READMEs.
- **`README.md`**: add `workflow_dispatch:` to the `Package checks` template, document the deploy-triggering events, and point at the new example.
- **`examples/README.md`**: usage section for the new example, following the `lock-threads` pattern.

## Event behavior

| event | before | after |
| --- | --- | --- |
| `push` | build + deploy | build + deploy |
| `pull_request` | build + verify | build + verify |
| `schedule` | build + verify | build + verify |
| `workflow_dispatch` | build + verify (no deploy) | build + **deploy** |
| `repository_dispatch` | build + verify (no deploy) | build + **deploy** |

If the pre-step's output is ever empty, `!= 'true'` means the job falls back to verify-only — it will not deploy by accident.

## Testing notes

Both YAML files and the README's embedded template parse cleanly, and the pre-step is ordered ahead of both consumers of its output. This repo has no test suite, so the meaningful check is a consuming repo copying `examples/website.yaml` (pointed at `@schloerke/issue-25-website-dispatch`) and confirming that *Run workflow* actually deploys to `gh-pages`.

