### PR TITLE
docs: Add update-v1-tag skill and point release docs at it

### DIFF
--- a/.claude/skills/releasing-v1-tag/SKILL.md
+++ b/.claude/skills/releasing-v1-tag/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: releasing-v1-tag
+description: Use when merged changes in shiny-workflows need to reach consumer repos, when moving or force-pushing the v1 tag, when rolling v1 back, or when a consumer pinned to @v1 is not picking up a merged fix.
+---
+
+# Releasing the v1 tag
+
+## Overview
+
+Consumers reference this repo only through the moving `v1` tag (`rstudio/shiny-workflows/...@v1`). Merging to `main` ships nothing. Force-moving `v1` ships *everything* on `main` to *every* consumer repo at once, with no staged rollout and no review.
+
+**Treat moving `v1` as a production deploy, not a git chore.**
+
+## The confirmation gate
+
+**STOP after the pre-flight checks. Show the user what will ship and get explicit approval before the force-push.**
+
+No exceptions:
+
+- Not when the user said "merge and release" earlier — approval to merge is not approval to deploy.
+- Not when your own change is trivial. `v1` ships every unreleased commit on `main`, not just yours.
+- Not when the commit range "looks obviously fine". You are not the one who owns the consumer repos.
+- Not when re-running after a failed push. Re-confirm.
+
+Silence is not approval. Ask, then wait.
+
+| Rationalization | Reality |
+|---|---|
+| "The user asked for a release, so pushing is implied" | They asked for *a* release. Show them *which commits* first — the range usually holds other people's unreleased work. |
+| "It's docs-only" | Then there is no urgency, so there is no cost to asking. |
+| "CLAUDE.md documents the commands, so just run them" | It documents *how*, not *whether now*. |
+| "I'll push and roll back if it breaks" | Consumer CI runs in the gap. Roll-forward damage is already done. |
+
+## Procedure
+
+1. **Verify the merge landed:** `gh pr view <N> --json state,mergeCommit`.
+2. **Fetch, never trust local refs:** `git fetch origin main --tags`. Local `main` is often stale or checked out in another worktree; the current branch HEAD is often the *pre-squash* commit. Always tag `origin/main` explicitly.
+3. **Check `main` is green:** `gh run list --branch main --limit 5`. A red `main` becomes a red `v1` for everyone.
+4. **List what ships:** `git log --oneline v1..origin/main`.
+5. **Check for leftover branch refs:** `grep -rn '@' --include='*.yaml' .github/workflows */action.yaml | grep -vE '@v1|@[0-9a-f]{40}'`. A cross-reference still pointing at a test branch breaks consumers the moment the tag moves.
+6. **Record the rollback point:** `git rev-parse v1`.
+7. **Confirm with the user** (see gate above) — show the step-4 commit list and the step-6 sha.
+8. **Move and push:**
+   ```bash
+   git tag -f v1 origin/main
+   git rev-parse v1              # must equal origin/main
+   git push origin v1 --force
+   ```
+9. **Verify:** `git ls-remote origin refs/tags/v1` equals `origin/main`.
+
+## Notes
+
+- Prefer `git push origin v1 --force` over `git push origin --tags -f`. Same result today, but the scoped push cannot collaterally move some other tag.
+- Keep `v1` **lightweight**. No `-a`/`-m` — annotating changes what `actions/checkout` resolves.
+- **Rollback:** `git tag -f v1 <old-sha> && git push origin v1 --force`.
+
+## Red flags — stop and ask
+
+- About to run `git push ... --force` without having shown the user a commit list
+- Tagging `HEAD`, `main`, or a branch name instead of `origin/main`
+- `git log v1..origin/main` contains commits you did not write and did not mention
+- Skipping the pre-flight checks because "it's just a tag move"

--- a/.claude/skills/update-v1-tag/SKILL.md
+++ b/.claude/skills/update-v1-tag/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: releasing-v1-tag
-description: Use when merged changes in shiny-workflows need to reach consumer repos, when moving or force-pushing the v1 tag, when rolling v1 back, or when a consumer pinned to @v1 is not picking up a merged fix.
+name: update-v1-tag
+description: Use when merged changes in shiny-workflows need to reach consumer repos, when a PR has just been merged to main, when moving or force-pushing the v1 tag, when rolling v1 back, or when a consumer pinned to @v1 is not picking up a merged fix.
 ---
 
-# Releasing the v1 tag
+# Updating the v1 tag
 
 ## Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,11 @@ Two layers, plus internal helpers:
 
 ## Releasing changes
 
-Workflows are consumed via the `v1` tag. After merging changes, force-move the tag:
+Workflows are consumed via the `v1` tag. Until the tag moves, consumers on `@v1` do not see merged changes — merging a PR ships nothing on its own.
 
-```bash
-git tag -f v1
-git push origin --tags -f
-```
+**After a PR is merged to `main`, use the `update-v1-tag` skill** (`.claude/skills/update-v1-tag/SKILL.md`) to move the tag. Do not run the tag commands from memory: the skill carries the pre-flight checks, tags `origin/main` explicitly (bare `git tag -f v1` tags `HEAD`, which is wrong whenever you are not sitting on the merge commit), stops for explicit user confirmation before the force-push, and records a rollback point.
 
-Until the tag moves, consumers on `@v1` do not see merged changes. When testing changes from a consumer repo, reference the branch instead (`@<branch-name>`).
+When testing changes from a consumer repo, reference the branch instead (`@<branch-name>`).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -177,12 +177,9 @@ Reasons to NOT consider a feature:
 
 ### Updates to workflows or actions
 
-If updates are made to the workflows, the `v1` tag must be (forcefully) moved forward to the latest value within the `rstudio/shiny-workflows`. To do this, run:
+If updates are made to the workflows, the `v1` tag must be (forcefully) moved forward to the latest commit on `main` within `rstudio/shiny-workflows`. Until the tag moves, consumers on `@v1` do not see merged changes.
 
-``` bash
-git tag -f v1
-git push origin --tags -f
-```
+Moving the tag ships every unreleased commit on `main` to every consumer repo at once, so it is a deploy rather than a git chore. The procedure — pre-flight checks, the commit list to review, the force-push, and how to roll back — lives in [`.claude/skills/update-v1-tag/SKILL.md`](./.claude/skills/update-v1-tag/SKILL.md). Follow it there rather than running the commands from memory; if you are working with Claude Code, ask it to update the `v1` tag and it will use that skill.
 
 
 


### PR DESCRIPTION
## Summary

Adds `.claude/skills/update-v1-tag/SKILL.md`, a project skill (checked in, so the whole team gets it) covering the one operation in this repo that reaches every consumer at once: force-moving the `v1` tag. `README.md` and `CLAUDE.md` now point at the skill instead of restating the commands.

The skill's centerpiece is a **mandatory confirmation gate** — pre-flight checks run, then the agent stops, shows the user the exact `git log v1..origin/main` commit list plus the rollback sha, and waits for explicit approval before force-pushing. This exists because moving `v1` ships *every* unreleased commit on `main`, not just the one you merged, so the person releasing is usually also shipping other people's work. The gate is backed by a rationalization table (approval-to-merge is not approval-to-deploy, "it's docs-only", "I'll roll back if it breaks") since this is a discipline failure, not a knowledge gap.

Beyond the gate it encodes hazards that surfaced during testing: tag `origin/main` explicitly rather than `HEAD` (which may be a pre-squash branch commit) or local `main` (often stale, or owned by another worktree); prefer scoped `git push origin v1 --force` over `--tags -f`, which can collaterally move unrelated tags; keep `v1` lightweight, since annotating changes what `actions/checkout` resolves; and grep for cross-references left pointing at a test branch.

**Doc fix:** both `README.md` and `CLAUDE.md` documented bare `git tag -f v1`, which tags `HEAD` — wrong whenever you are not sitting exactly on the merge commit, and this repo's normal flow (squash merge, then release from a feature-branch worktree) puts you somewhere else. Rather than correcting the commands in two more places, both now defer to the skill as the single source of truth; duplicating them is what let the bug persist. `CLAUDE.md` additionally instructs that the skill be used after a PR is merged to `main`.

Docs only — no workflow or action behavior changes.

## Verification

Developed against a baseline: an agent given "a PR merged, make it available to consumers" *without* the skill produced correct mechanics (`CLAUDE.md` already documented the commands) but went straight from checks to force-pushing, with no point at which it asked the user. Re-running the identical prompt with the skill present, the agent stopped at the gate, refused to continue, and specifically called out that two of the three shipping commits weren't the requester's — it also independently flagged the bare-`git tag -f v1` bug in the docs.

To reproduce: `claude` in this repo, then ask it to make a merged change available to consumer repos. It should surface the commit list and stop rather than push.