### PR TITLE
examples: Add pkg-r, R-CMD-check, and routine examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,13 +43,14 @@ When testing changes from a consumer repo, reference the branch instead (`@<bran
 
 ## Example workflows (`examples/`)
 
-`examples/` holds the copy-into-your-repo caller workflows for consumer repos: `package-checks.yaml` (all three workflows in one, the default) plus per-workflow files (`R-CMD-check.yaml`, `routine.yaml`, `website.yaml`) and `lock-threads.yaml`. Every reusable workflow in `.github/workflows/` should have a corresponding example file here.
+`examples/` holds the copy-into-your-repo caller workflows for consumer repos: `pkg-r.yaml` (all three workflows in one, the default) plus per-workflow files (`R-CMD-check.yaml`, `routine.yaml`, `website.yaml`) and `lock-threads.yaml`. Every reusable workflow in `.github/workflows/` should have a corresponding example file here.
 
 When adding or editing an example:
 
 - **Every example gets `workflow_dispatch:`.** Consumers need to trigger these by hand from the Actions tab. In particular, never add `repository_dispatch` without also adding `workflow_dispatch` — a workflow that can be triggered by another repo but not by a human in this one is a debugging dead end.
 - Give `repository_dispatch` an explicit `types:` list (e.g. `repository_dispatch: { types: [website] }`) so that unrelated dispatches don't fire it.
 - Reference the reusable workflow at `@v1`, matching the rest of the repo.
-- Open with the `# Workflow derived from https://github.com/rstudio/shiny-workflows` header comment, and — for any file that splits a job out of `Package checks` — a `NOTE:` telling the consumer to remove that job from their `package-checks.yaml`.
+- Open with the `# Workflow derived from https://github.com/rstudio/shiny-workflows` header comment, and — for any file that splits a job out of `Package checks` — a `NOTE:` telling the consumer to remove that job from their `pkg-r.yaml`.
+- Do not add a `schedule:` trigger. Consumer repos decide their own cadence; the only example that is schedule-driven is `lock-threads.yaml`, where the schedule *is* the feature.
 - Set a `concurrency:` group. Cancel superseded pull request runs, but do not cancel `routine` (it pushes commits back and a run cancelled mid-push is worse than a redundant run) and do not cancel `website` pushes (two deploys must not race on `gh-pages`).
 - Document the new file in `examples/README.md` with a `usethis::use_github_action(url = ...)` snippet, and link it from the matching workflow bullet in the top-level `README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,16 @@ When testing changes from a consumer repo, reference the branch instead (`@<bran
 - README.md documents all workflow/action parameters; keep it in sync when adding or changing inputs (past commits do this, e.g. "docs: Update documentation with missing workflow and action parameters").
 - Each action directory has its own README with an inputs table — update it alongside `action.yaml`.
 - Feature policy (from README): adopt a feature if 2+ repos need it or all repos could benefit (e.g., phantomJS, tinytex auto-install); reject features that appease a single repo or impose behavior other repos won't adopt.
+
+## Example workflows (`examples/`)
+
+`examples/` holds the copy-into-your-repo caller workflows for consumer repos: `package-checks.yaml` (all three workflows in one, the default) plus per-workflow files (`R-CMD-check.yaml`, `routine.yaml`, `website.yaml`) and `lock-threads.yaml`. Every reusable workflow in `.github/workflows/` should have a corresponding example file here.
+
+When adding or editing an example:
+
+- **Every example gets `workflow_dispatch:`.** Consumers need to trigger these by hand from the Actions tab. In particular, never add `repository_dispatch` without also adding `workflow_dispatch` — a workflow that can be triggered by another repo but not by a human in this one is a debugging dead end.
+- Give `repository_dispatch` an explicit `types:` list (e.g. `repository_dispatch: { types: [website] }`) so that unrelated dispatches don't fire it.
+- Reference the reusable workflow at `@v1`, matching the rest of the repo.
+- Open with the `# Workflow derived from https://github.com/rstudio/shiny-workflows` header comment, and — for any file that splits a job out of `Package checks` — a `NOTE:` telling the consumer to remove that job from their `package-checks.yaml`.
+- Set a `concurrency:` group. Cancel superseded pull request runs, but do not cancel `routine` (it pushes commits back and a run cancelled mid-push is worse than a redundant run) and do not cancel `website` pushes (two deploys must not race on `gh-pages`).
+- Document the new file in `examples/README.md` with a `usethis::use_github_action(url = ...)` snippet, and link it from the matching workflow bullet in the top-level `README.md`.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ on:
   push:
     branches: [main, rc-**]
   pull_request:
-  schedule:
-    - cron: '0 8 * * 1' # every monday
   workflow_dispatch:
 
 name: Package checks
@@ -34,20 +32,18 @@ jobs:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
 ```
 
-> Note: Adjust the `8` in the schedule to match the number of letters in the package name to insert some time variance. This helps mitigate PAT rate limits when testing many packages on a schedule.
-
-This file is also available as [`examples/package-checks.yaml`](./examples/package-checks.yaml), so it can be installed directly:
+This file is also available as [`examples/pkg-r.yaml`](./examples/pkg-r.yaml), so it can be installed directly:
 
 ```r
 usethis::use_github_action(
   url = file.path(
     "https://raw.githubusercontent.com/rstudio/shiny-workflows",
-    "main/examples/package-checks.yaml"
+    "main/examples/pkg-r.yaml"
   )
 )
 ```
 
-To run any of the three workflows on its own triggers or schedule, adopt the matching file from [`examples/`](./examples/README.md) instead and drop that job from `Package checks`.
+To run any of the three workflows on its own triggers, adopt the matching file from [`examples/`](./examples/README.md) instead and drop that job from `Package checks`.
 
 ## Workflows
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ jobs:
 
 > Note: Adjust the `8` in the schedule to match the number of letters in the package name to insert some time variance. This helps mitigate PAT rate limits when testing many packages on a schedule.
 
+This file is also available as [`examples/package-checks.yaml`](./examples/package-checks.yaml), so it can be installed directly:
+
+```r
+usethis::use_github_action(
+  url = file.path(
+    "https://raw.githubusercontent.com/rstudio/shiny-workflows",
+    "main/examples/package-checks.yaml"
+  )
+)
+```
+
+To run any of the three workflows on its own triggers or schedule, adopt the matching file from [`examples/`](./examples/README.md) instead and drop that job from `Package checks`.
+
 ## Workflows
 
 
@@ -67,6 +80,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * Calls `npm test` / `yarn test`
     * Checks for outdated `staticimports`
   * Packages included in the `DESCRIPTION` field `Config/Needs/routine` will also be installed
+  * To run the tasks as their own workflow, so that they can be re-run on demand without the rest of `Package checks`, copy [`examples/routine.yaml`](./examples/routine.yaml) into your repo and drop the `routine` job from `Package checks`. See [the examples README](./examples/README.md#routine).
   * Parameters:
     * `extra-packages`, `cache-version`, `pandoc-version`: Same as in `website.yaml`
     * `node-version`: Version of `node.js` to install. Defaults to `"current"`.
@@ -79,6 +93,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).
 * `R-CMD-check.yaml`
   * Performs `R CMD check .` on your package
+  * To run the check matrix as its own workflow, so that it can be re-run on demand without the rest of `Package checks`, copy [`examples/R-CMD-check.yaml`](./examples/R-CMD-check.yaml) into your repo and drop the `R-CMD-check` job from `Package checks`. See [the examples README](./examples/README.md#r-cmd-check).
   * Parameters:
     * `extra-packages`, `cache-version`, `pandoc-version`: Same as in `website.yaml`
     * `extra-check-args`, `extra-check-build-args`: Arguments passed in addition to the default check `args`/`build-args` of https://github.com/r-lib/actions/blob/v2/check-r-package/

--- a/examples/R-CMD-check.yaml
+++ b/examples/R-CMD-check.yaml
@@ -1,0 +1,31 @@
+# Workflow derived from https://github.com/rstudio/shiny-workflows
+#
+# Runs `R CMD check` across the macOS / Windows / Ubuntu matrix as its own
+# workflow, so the check matrix can be re-run on demand without also re-running
+# `routine` or rebuilding the website.
+#
+# NOTE: If you adopt this workflow, remove the `R-CMD-check` job from your
+# `Package checks` workflow. Otherwise the matrix runs twice on every push.
+on:
+  push:
+    branches: [main, rc-**]
+  pull_request:
+  schedule:
+    # Adjust the `8` to match the number of letters in the package name. The
+    # time variance helps mitigate PAT rate limits when many packages are
+    # tested on the same schedule.
+    - cron: '0 8 * * 1' # every monday
+  workflow_dispatch:
+  repository_dispatch: { types: [R-CMD-check] }
+
+name: R-CMD-check
+
+concurrency:
+  # Cancel superseded runs on a pull request; let everything else run to
+  # completion so scheduled and push results are never dropped
+  group: R-CMD-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  R-CMD-check:
+    uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1

--- a/examples/R-CMD-check.yaml
+++ b/examples/R-CMD-check.yaml
@@ -10,11 +10,6 @@ on:
   push:
     branches: [main, rc-**]
   pull_request:
-  schedule:
-    # Adjust the `8` to match the number of letters in the package name. The
-    # time variance helps mitigate PAT rate limits when many packages are
-    # tested on the same schedule.
-    - cron: '0 8 * * 1' # every monday
   workflow_dispatch:
   repository_dispatch: { types: [R-CMD-check] }
 
@@ -22,7 +17,7 @@ name: R-CMD-check
 
 concurrency:
   # Cancel superseded runs on a pull request; let everything else run to
-  # completion so scheduled and push results are never dropped
+  # completion so push results are never dropped
   group: R-CMD-check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,68 @@
 # Examples
 
+Copy-and-adopt workflow files for consumer repos. Every example can be installed with `usethis::use_github_action(url = ...)`, and every example can be triggered by hand from the **Actions** tab (*Run workflow*) or with `gh workflow run <file>`.
+
+**Start with [`package-checks.yaml`](./package-checks.yaml)**, which runs the website, routine, and `R CMD check` workflows together. Split any of them out into their own file — [`website.yaml`](./website.yaml), [`routine.yaml`](./routine.yaml), [`R-CMD-check.yaml`](./R-CMD-check.yaml) — when you want it on its own triggers or schedule, and remove the matching job from `package-checks.yaml` so the work isn't done twice.
+
+## package-checks
+
+The standard shiny-verse workflow: builds the `{pkgdown}` site, runs the routine housekeeping tasks, and runs `R CMD check` across the full matrix, on every push and pull request plus a weekly schedule.
+
+### Usage
+
+```r
+usethis::use_github_action(
+  url = file.path(
+    "https://raw.githubusercontent.com/rstudio/shiny-workflows",
+    "main/examples/package-checks.yaml"
+  )
+)
+```
+
+Adjust the `8` in `cron: '0 8 * * 1'` to match the number of letters in the package name. This inserts some time variance and helps mitigate PAT rate limits when many packages are tested on the same schedule.
+
+Each job accepts the same parameters as the workflow it calls; add a `with:` block to set them.
+
+## R-CMD-check
+
+Runs the `R CMD check` matrix as its own workflow, rather than as the `R-CMD-check` job inside `Package checks`. Useful when you want to re-run just the check matrix on demand, or put it on a different schedule than the rest of the checks.
+
+### Usage
+
+```r
+usethis::use_github_action(
+  url = file.path(
+    "https://raw.githubusercontent.com/rstudio/shiny-workflows",
+    "main/examples/R-CMD-check.yaml"
+  )
+)
+```
+
+**Remove the `R-CMD-check` job from your `Package checks` workflow when you adopt this file**, otherwise the matrix runs twice on every push.
+
+The workflow accepts the same parameters as `R-CMD-check.yaml`; add a `with:` block to the `R-CMD-check` job to set them.
+
+## routine
+
+Runs the routine housekeeping tasks (air formatting, `usethis::use_tidy_description()`, `devtools::document()`, `build_readme()`, covr, lintr, npm/yarn build and test, staticimports) as its own workflow.
+
+Routine only commits its results back on `pull_request` events from a non-forked branch. On `push` and `schedule` events it verifies that nothing needed to change and fails if something did.
+
+### Usage
+
+```r
+usethis::use_github_action(
+  url = file.path(
+    "https://raw.githubusercontent.com/rstudio/shiny-workflows",
+    "main/examples/routine.yaml"
+  )
+)
+```
+
+**Remove the `routine` job from your `Package checks` workflow when you adopt this file**, otherwise the tasks run twice on every push.
+
+The workflow accepts the same parameters as `routine.yaml`; add a `with:` block to the `routine` job to set them.
+
 ## website
 
 Builds and deploys the `{pkgdown}` site as its own workflow, rather than as the `website` job inside `Package checks`. The site is still built on every push and pull request, and it can additionally be rebuilt on demand (for example, while debugging a rendering problem) without pushing a commit or re-running the full check matrix.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,11 +2,11 @@
 
 Copy-and-adopt workflow files for consumer repos. Every example can be installed with `usethis::use_github_action(url = ...)`, and every example can be triggered by hand from the **Actions** tab (*Run workflow*) or with `gh workflow run <file>`.
 
-**Start with [`package-checks.yaml`](./package-checks.yaml)**, which runs the website, routine, and `R CMD check` workflows together. Split any of them out into their own file — [`website.yaml`](./website.yaml), [`routine.yaml`](./routine.yaml), [`R-CMD-check.yaml`](./R-CMD-check.yaml) — when you want it on its own triggers or schedule, and remove the matching job from `package-checks.yaml` so the work isn't done twice.
+**Start with [`pkg-r.yaml`](./pkg-r.yaml)**, which runs the website, routine, and `R CMD check` workflows together. Split any of them out into their own file — [`website.yaml`](./website.yaml), [`routine.yaml`](./routine.yaml), [`R-CMD-check.yaml`](./R-CMD-check.yaml) — when you want it on its own triggers, and remove the matching job from `pkg-r.yaml` so the work isn't done twice.
 
-## package-checks
+## pkg-r
 
-The standard shiny-verse workflow: builds the `{pkgdown}` site, runs the routine housekeeping tasks, and runs `R CMD check` across the full matrix, on every push and pull request plus a weekly schedule.
+The standard shiny-verse workflow: builds the `{pkgdown}` site, runs the routine housekeeping tasks, and runs `R CMD check` across the full matrix, on every push and pull request.
 
 ### Usage
 
@@ -14,18 +14,16 @@ The standard shiny-verse workflow: builds the `{pkgdown}` site, runs the routine
 usethis::use_github_action(
   url = file.path(
     "https://raw.githubusercontent.com/rstudio/shiny-workflows",
-    "main/examples/package-checks.yaml"
+    "main/examples/pkg-r.yaml"
   )
 )
 ```
-
-Adjust the `8` in `cron: '0 8 * * 1'` to match the number of letters in the package name. This inserts some time variance and helps mitigate PAT rate limits when many packages are tested on the same schedule.
 
 Each job accepts the same parameters as the workflow it calls; add a `with:` block to set them.
 
 ## R-CMD-check
 
-Runs the `R CMD check` matrix as its own workflow, rather than as the `R-CMD-check` job inside `Package checks`. Useful when you want to re-run just the check matrix on demand, or put it on a different schedule than the rest of the checks.
+Runs the `R CMD check` matrix as its own workflow, rather than as the `R-CMD-check` job inside `Package checks`. Useful when you want to re-run just the check matrix on demand, or on different triggers than the rest of the checks.
 
 ### Usage
 
@@ -46,7 +44,7 @@ The workflow accepts the same parameters as `R-CMD-check.yaml`; add a `with:` bl
 
 Runs the routine housekeeping tasks (air formatting, `usethis::use_tidy_description()`, `devtools::document()`, `build_readme()`, covr, lintr, npm/yarn build and test, staticimports) as its own workflow.
 
-Routine only commits its results back on `pull_request` events from a non-forked branch. On `push` and `schedule` events it verifies that nothing needed to change and fails if something did.
+Routine only commits its results back on `pull_request` events from a non-forked branch. On `push` events it verifies that nothing needed to change and fails if something did.
 
 ### Usage
 

--- a/examples/package-checks.yaml
+++ b/examples/package-checks.yaml
@@ -1,0 +1,38 @@
+# Workflow derived from https://github.com/rstudio/shiny-workflows
+#
+# NOTE: This Shiny team GHA workflow is overkill for most R packages.
+# For most R packages it is better to use https://github.com/r-lib/actions
+#
+# Runs the website, routine, and R CMD check workflows together. To run any of
+# them on their own schedule or triggers, copy the matching example file
+# (`website.yaml`, `routine.yaml`, `R-CMD-check.yaml`) instead and remove that
+# job from here.
+on:
+  push:
+    branches: [main, rc-**]
+  pull_request:
+  schedule:
+    # Adjust the `8` to match the number of letters in the package name. The
+    # time variance helps mitigate PAT rate limits when many packages are
+    # tested on the same schedule.
+    - cron: '0 8 * * 1' # every monday
+  workflow_dispatch:
+  repository_dispatch: { types: [package-checks] }
+
+name: Package checks
+
+concurrency:
+  # Cancel superseded runs on a pull request, but let pushes queue up so that
+  # `routine` and `website` never race on the branch or on `gh-pages`
+  group: package-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  website:
+    uses: rstudio/shiny-workflows/.github/workflows/website.yaml@v1
+  routine:
+    uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
+    with:
+      format-r-code: true
+  R-CMD-check:
+    uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1

--- a/examples/pkg-r.yaml
+++ b/examples/pkg-r.yaml
@@ -4,27 +4,21 @@
 # For most R packages it is better to use https://github.com/r-lib/actions
 #
 # Runs the website, routine, and R CMD check workflows together. To run any of
-# them on their own schedule or triggers, copy the matching example file
-# (`website.yaml`, `routine.yaml`, `R-CMD-check.yaml`) instead and remove that
-# job from here.
+# them on their own triggers, copy the matching example file (`website.yaml`,
+# `routine.yaml`, `R-CMD-check.yaml`) instead and remove that job from here.
 on:
   push:
     branches: [main, rc-**]
   pull_request:
-  schedule:
-    # Adjust the `8` to match the number of letters in the package name. The
-    # time variance helps mitigate PAT rate limits when many packages are
-    # tested on the same schedule.
-    - cron: '0 8 * * 1' # every monday
   workflow_dispatch:
-  repository_dispatch: { types: [package-checks] }
+  repository_dispatch: { types: [pkg-r] }
 
 name: Package checks
 
 concurrency:
   # Cancel superseded runs on a pull request, but let pushes queue up so that
   # `routine` and `website` never race on the branch or on `gh-pages`
-  group: package-checks-${{ github.event.pull_request.number || github.ref }}
+  group: pkg-r-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/examples/routine.yaml
+++ b/examples/routine.yaml
@@ -5,8 +5,8 @@
 # be re-run on demand without also running the full `R CMD check` matrix.
 #
 # Routine only commits its results back on `pull_request` events from a
-# non-forked branch. On `push` and `schedule` events it verifies that nothing
-# needed to change and fails if something did.
+# non-forked branch. On `push` events it verifies that nothing needed to change
+# and fails if something did.
 #
 # NOTE: If you adopt this workflow, remove the `routine` job from your
 # `Package checks` workflow. Otherwise the tasks run twice on every push.
@@ -14,11 +14,6 @@ on:
   push:
     branches: [main, rc-**]
   pull_request:
-  schedule:
-    # Adjust the `8` to match the number of letters in the package name. The
-    # time variance helps mitigate PAT rate limits when many packages are
-    # tested on the same schedule.
-    - cron: '0 8 * * 1' # every monday
   workflow_dispatch:
   repository_dispatch: { types: [routine] }
 

--- a/examples/routine.yaml
+++ b/examples/routine.yaml
@@ -1,0 +1,37 @@
+# Workflow derived from https://github.com/rstudio/shiny-workflows
+#
+# Runs the routine housekeeping tasks (formatting, documentation, README,
+# covr, lintr, JS build/test, staticimports) as its own workflow, so they can
+# be re-run on demand without also running the full `R CMD check` matrix.
+#
+# Routine only commits its results back on `pull_request` events from a
+# non-forked branch. On `push` and `schedule` events it verifies that nothing
+# needed to change and fails if something did.
+#
+# NOTE: If you adopt this workflow, remove the `routine` job from your
+# `Package checks` workflow. Otherwise the tasks run twice on every push.
+on:
+  push:
+    branches: [main, rc-**]
+  pull_request:
+  schedule:
+    # Adjust the `8` to match the number of letters in the package name. The
+    # time variance helps mitigate PAT rate limits when many packages are
+    # tested on the same schedule.
+    - cron: '0 8 * * 1' # every monday
+  workflow_dispatch:
+  repository_dispatch: { types: [routine] }
+
+name: routine
+
+concurrency:
+  # Never cancel in progress: this workflow pushes commits back to the branch,
+  # and a run cancelled mid-push is worse than a redundant run
+  group: routine-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  routine:
+    uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
+    with:
+      format-r-code: true


### PR DESCRIPTION
Closes #21. Closes #22.

## #22 — example files for the remaining workflows

`examples/` only had `website.yaml` and `lock-threads.yaml`. Adds the three missing caller workflows:

- **`examples/pkg-r.yaml`** — the combined website + routine + `R CMD check` workflow that the top-level README already shows inline, now installable with `usethis::use_github_action(url = ...)` instead of copy-paste.
- **`examples/R-CMD-check.yaml`** — the check matrix on its own triggers, for re-running just the matrix without rebuilding the site.
- **`examples/routine.yaml`** — the housekeeping tasks on their own triggers.

None of them ship a `schedule:` trigger — consumer repos decide their own cadence. The `cron` and the "adjust the `8`" note are also dropped from the top-level README snippet, so it stays in sync with `pkg-r.yaml`. `lock-threads.yaml` keeps its schedule, since that is the point of that workflow.

Each split-out file carries a `NOTE:` reminding the consumer to drop the matching job from `Package checks`, and each is documented in `examples/README.md` and linked from the matching workflow bullet in the top-level `README.md`.

## #21 — `workflow_dispatch` wherever `repository_dispatch` appears

All existing workflows already satisfied this, so there was nothing to fix in the YAML — the gap was that nothing wrote the rule down. The new `## Example workflows (examples/)` section in `CLAUDE.md` records it, along with the rest of the conventions for adding an example: explicit `repository_dispatch` `types:`, `@v1` refs, the derived-from header comment, no `schedule:`, the `concurrency:` rules (and why `routine` and `website` pushes must *not* be cancelled), and the two docs files to update.

All example files pass `actionlint`.
