### PR TITLE
license-note: Make the routine step opt-in

### DIFF
--- a/.github/workflows/routine.yaml
+++ b/.github/workflows/routine.yaml
@@ -56,9 +56,9 @@ on:
           vignettes/*.png
         required: false
       license-note:
-        description: "If true, will update the bundled JavaScript dependency list in `LICENSE.note`. Only takes effect if `LICENSE.note` contains the generated-block markers."
+        description: "If true, will update the bundled JavaScript dependency list in `LICENSE.note`. Opt-in: also requires `LICENSE.note` to contain the generated-block markers."
         type: boolean
-        default: true
+        default: false
         required: false
     # secrets:
     #   token:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * Checks code coverage with `covr` if `codecov.yml` exists
     * Checks for broken lints if `.lintr` exists
     * Calls `npm build` / `yarn build` and commits any changes in `inst`, `srcts`, and `srcjs`.
-    * Updates the bundled JavaScript dependency list in `LICENSE.note` (if it contains the generated-block markers), and comments on the PR when it changes. See [the `license-note` README](./license-note/README.md).
+    * Updates the bundled JavaScript dependency list in `LICENSE.note` and comments on the PR when it changes, if `license-note: true`. See [the `license-note` README](./license-note/README.md).
     * Calls `npm test` / `yarn test`
     * Checks for outdated `staticimports`
   * Packages included in the `DESCRIPTION` field `Config/Needs/routine` will also be installed
@@ -89,7 +89,7 @@ There are three main reusable workflows to be used by packages in the shiny-vers
     * `check-js`: If `true`, will check for a `package.json` file and run `npm install` / `yarn install` and `npm build` / `yarn build` if it exists. Defaults to `true`.
     * `js-working-directory`: Folder that contains the `package.json` file. Defaults to the working directory input.
     * `optimize-pngs`: Newline-separated [git pathspecs](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec) of tracked PNG files to losslessly optimize with [`oxipng`](https://github.com/oxipng/oxipng). Defaults to `man/figures/*.png` and `vignettes/*.png`. Note that `*` matches `/` in a pathspec, so nested folders are included. Files under a `_snaps/` folder are never optimized, as `testthat::compare_file_binary()` compares snapshots byte for byte and optimizing one would keep it from matching a freshly generated screenshot. Set to `false` (or an empty string) to disable. See the [`optimize-pngs`](optimize-pngs/) action for details.
-    * `license-note`: If `true`, updates the bundled JavaScript dependency list in `LICENSE.note`. Only takes effect if `LICENSE.note` contains the generated-block markers, so this is a no-op until a repo opts in. Defaults to `true`. See [the `license-note` README](./license-note/README.md).
+    * `license-note`: If `true`, updates the bundled JavaScript dependency list in `LICENSE.note`. Defaults to `false` — set it to `true` and add the generated-block markers to `LICENSE.note` to opt in. See [the `license-note` README](./license-note/README.md).
     * `working-directory`: The working directory where all checks are executed. Defaults to `"."` (repository root).
 * `R-CMD-check.yaml`
   * Performs `R CMD check .` on your package

--- a/license-note/README.md
+++ b/license-note/README.md
@@ -14,9 +14,20 @@ of the installed `node_modules` and rewrites the list of components in
 
 ## Opting in
 
-The action only rewrites the region between two marker lines, so the rest of
-`LICENSE.note` — the summary paragraph, and any components that do not come from
-npm — stays under your control. A repo opts in by adding the markers once:
+Opting in takes two steps. In `routine.yaml`, this is off by default, so turn it
+on in your caller workflow:
+
+```yaml
+jobs:
+  routine:
+    uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
+    with:
+      license-note: true
+```
+
+Then add the markers to `LICENSE.note`. The action only rewrites the region
+between the two marker lines, so the rest of the file — the summary paragraph,
+and any components that do not come from npm — stays under your control:
 
 ```
 The example package as a whole is distributed under MIT. The example package


### PR DESCRIPTION
Follow-up to #69: defaults the `license-note` input to `false`.

The marker check already meant the step did nothing in a repo that had not opted in — no markers, no work. But that left the opt-in implicit and one-sided: a repo that happens to have a `LICENSE.note` with matching markers would start getting auto-commits and PR comments purely because `v1` moved. Turning something on for a consumer without them asking is the wrong default for this repo's `@v1` model.

Opting in is now explicit on both ends:

```yaml
jobs:
  routine:
    uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
    with:
      license-note: true
```

plus the marker pair in `LICENSE.note`.

No behavior change for anyone who has not opted in, since the step was already a no-op for them. Docs updated in both READMEs.

rstudio/shiny#4426 is updated to pass `license-note: true`.